### PR TITLE
Adding native support for multi-sig parent transaction generation for approval + execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs = "5.0"
-rand = "0.8"
 borsh = "1.5.7"
 colored = "2.2.0"
 dialoguer = "0.11.0"
@@ -26,7 +25,6 @@ tabled = "0.15"
 
 solana-client="2.0.0"
 solana-clap-v3-utils = "2.2.0"
-solana-signature = "2.0.0"
 solana-instruction = {version = "2.0.0", features = ["bincode"]}
 solana-pubkey = {version = "2.4.0", features = ["borsh", "curve25519"]}
 solana-keypair = "2.0.0"
@@ -38,7 +36,3 @@ solana-system-interface = "1.0.0"
 solana-rent = "2.0.0"
 solana-commitment-config = "2.0.0"
 solana-hash = "2.0.0"
-bs58 = "0.5"
-base64 = "0.22"
-bincode = "1.3"
-anyhow = "1.0.99"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The tool saves configuration to `~/.feature-gate-multisig-tool/config.json`:
     "https://api.testnet.solana.com",
     "https://api.mainnet-beta.solana.com"
   ],
-  "fee_payer_path": "~/.config/solana/id.json"
+  "fee_payer_path": "usb://ledger"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ cargo test
 cargo test -- --nocapture
 ```
 
+## Testing setup
+
+To test multisigs use `squads-multisig-cli` to spin up a multisig and add the PDA Vault as a member of the feature gate multisig.
+
+```bash
+multisig-create --rpc-url <RPC_URL> --program-id <PROGRAM_ID> --keypair <KEYPAIR_PATH> --config-authority <CONFIG_AUTHORITY> --members <MEMBER_1> <MEMBER_2> ... --threshold <THRESHOLD>
+
+```
+
+see more info here https://docs.squads.so/main/development/cli/commands#multisig-create
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,21 @@ The tool saves configuration to `~/.feature-gate-multisig-tool/config.json`:
 ## Transaction Generation
 
 Once a multisig is created, use the transaction generation commands to:
-- Vote on Feature Activation Proposal (Index 0)
-- Vote on Feature Activation Revocation Proposal (Index 1)
+- Vote on Feature Activation Proposal (Index 1)
+- Vote on Feature Activation Revocation Proposal (Index 2)
 - Execute proposals when threshold is met
+
+### Parent → Child multisig voting
+
+If a parent multisig is configured to vote on a proposal in a child multisig, the child multisig must include the parent vault PDA as a member with Vote permission (not the parent multisig address itself).
+
+Why: During execution, the parent program can sign for its vault PDA using PDA seeds, but it cannot sign as the parent multisig address in CPI. Listing the parent multisig address as the voter will lead to missing/invalid signer errors. Listing the parent vault PDA avoids this and enables programmatic approval.
+
+What to add to the child multisig:
+- Member: Parent vault PDA (usually index 0)
+- Permissions: Vote (and optionally Execute if the parent should execute child proposals)
+
+The CLI will print a clear error and the exact PDA to add if the child multisig isn’t configured correctly.
 
 ## Network Support
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The tool saves configuration to `~/.feature-gate-multisig-tool/config.json`:
     "https://api.testnet.solana.com",
     "https://api.mainnet-beta.solana.com"
   ],
+  "network": "https://api.devnet.solana.com",
   "fee_payer_path": "usb://ledger"
 }
 ```

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -175,6 +175,9 @@ async fn deploy_to_single_network(
     )
     .await?;
 
+    // Fund the vault address (feature gate account) with rent-exempt lamports
+    create_and_send_funding_transaction(rpc_url, fee_payer_signer, &vault_address).await?;
+
     Ok(DeploymentResult {
         rpc_url: rpc_url.to_string(),
         multisig_address,

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -4,6 +4,7 @@ use crate::squads::{get_proposal_pda, get_vault_pda, Member, Permissions};
 use crate::utils::*;
 use colored::*;
 use eyre::Result;
+use solana_clap_v3_utils::keypair::signer_from_path;
 use solana_keypair::Keypair;
 use solana_signer::Signer;
 
@@ -23,8 +24,14 @@ pub async fn create_command(
     // Collect configuration and members
     let (final_threshold, mut members) = review_and_collect_configuration(config, threshold)?;
 
-    // Load fee payer keypair from CLI arg or config
-    let fee_payer_keypair = load_fee_payer_keypair(config, keypair_path)?;
+    // Load fee payer signer from CLI arg or config (supports hardware wallets via usb://ledger)
+    let fee_payer_path = keypair_path
+        .or_else(|| config.fee_payer_path.clone())
+        .ok_or_else(|| eyre::eyre!("Fee payer keypair path is required"))?;
+
+    let fee_payer_signer =
+        signer_from_path(&Default::default(), &fee_payer_path, "fee payer", &mut None)
+            .map_err(|e| eyre::eyre!("Failed to load fee payer: {}", e))?;
 
     // Create setup keypair (always separate from fee payer)
     let setup_keypair = Keypair::new();
@@ -56,10 +63,7 @@ pub async fn create_command(
 
     // Check fee payer balance on all networks before deployment
     if use_saved_networks && !saved_networks.is_empty() {
-        let fee_payer_pubkey = fee_payer_keypair
-            .as_ref()
-            .map(|kp| kp.pubkey())
-            .unwrap_or_else(|| setup_keypair.pubkey());
+        let fee_payer_pubkey = fee_payer_signer.pubkey();
 
         check_fee_payer_balance_on_networks(&fee_payer_pubkey, &saved_networks, 0.05).await?;
     }
@@ -69,7 +73,7 @@ pub async fn create_command(
             &saved_networks,
             &create_key,
             &setup_keypair,
-            &fee_payer_keypair,
+            &fee_payer_signer,
             &members,
             final_threshold,
         )
@@ -79,7 +83,7 @@ pub async fn create_command(
             config,
             &create_key,
             &setup_keypair,
-            &fee_payer_keypair,
+            &fee_payer_signer,
             &members,
             final_threshold,
         )
@@ -119,7 +123,7 @@ async fn deploy_to_single_network(
     total_networks: usize,
     create_key: &Keypair,
     setup_keypair: &Keypair,
-    fee_payer_keypair: &Option<Keypair>,
+    fee_payer_signer: &Box<dyn Signer>,
     members: &[Member],
     threshold: u16,
 ) -> Result<DeploymentResult> {
@@ -134,10 +138,7 @@ async fn deploy_to_single_network(
     //     members,
     // );
 
-    let signer_for_creation = fee_payer_keypair
-        .as_ref()
-        .map(|kp| kp as &dyn Signer)
-        .unwrap_or(setup_keypair as &dyn Signer);
+    let signer_for_creation = fee_payer_signer.as_ref();
 
     let (multisig_address, signature) = create_multisig(
         rpc_url.to_string(),
@@ -156,7 +157,7 @@ async fn deploy_to_single_network(
     // Create both activation and revocation transactions
     create_and_send_transaction_proposal(
         rpc_url,
-        fee_payer_keypair,
+        fee_payer_signer,
         setup_keypair,
         &multisig_address,
         "activation",
@@ -166,7 +167,7 @@ async fn deploy_to_single_network(
 
     create_and_send_transaction_proposal(
         rpc_url,
-        fee_payer_keypair,
+        fee_payer_signer,
         setup_keypair,
         &multisig_address,
         "revocation",
@@ -186,7 +187,7 @@ async fn deploy_to_saved_networks(
     networks: &[String],
     create_key: &Keypair,
     setup_keypair: &Keypair,
-    fee_payer_keypair: &Option<Keypair>,
+    fee_payer_signer: &Box<dyn Signer>,
     members: &[Member],
     threshold: u16,
 ) -> Result<Vec<DeploymentResult>> {
@@ -199,7 +200,7 @@ async fn deploy_to_saved_networks(
             networks.len(),
             create_key,
             setup_keypair,
-            fee_payer_keypair,
+            fee_payer_signer,
             members,
             threshold,
         )
@@ -231,7 +232,7 @@ async fn deploy_to_manual_networks(
     config: &Config,
     create_key: &Keypair,
     contributor_keypair: &Keypair,
-    fee_payer_keypair: &Option<Keypair>,
+    fee_payer_signer: &Box<dyn Signer>,
     members: &[Member],
     threshold: u16,
 ) -> Result<Vec<DeploymentResult>> {
@@ -248,7 +249,7 @@ async fn deploy_to_manual_networks(
             1,
             create_key,
             contributor_keypair,
-            fee_payer_keypair,
+            fee_payer_signer,
             members,
             threshold,
         )

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -16,18 +16,20 @@ pub async fn interactive_mode() -> Result<()> {
             "Create new feature gate multisig",
             "Show feature gate multisig details",
             "Show configuration",
-            "Transaction Generation",
+            "Approve/Execute Feature Gate Proposals",
             "Exit",
         ];
 
         let choice: &str = Select::new("What would you like to do?", options).prompt()?;
+
+        println!("In the current setup, only the fee payer keypair is used for transactions, hence for EOA voting fee payer = voting account. For multisig setup, the fee payer needs to be a member of the parent multisig.\n");
 
         match choice {
             "Create new feature gate multisig" => {
                 let feepayer_path = prompt_for_fee_payer_path(&config)?;
                 create_command(&mut config, None, vec![], Some(feepayer_path)).await?;
             }
-            "Transaction Generation" => {
+            "Approve/Execute Feature Gate Proposals" => {
                 let feature_gate_multisig_address =
                     prompt_for_pubkey("Enter the feature gate multisig address:")?;
                 let feature_gate_id = get_vault_pda(&feature_gate_multisig_address, 0, None).0;

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -16,7 +16,7 @@ pub async fn interactive_mode() -> Result<()> {
             "Create new feature gate multisig",
             "Show feature gate multisig details",
             "Show configuration",
-            "Approve/Execute Feature Gate Proposals",
+            "Approve/Execute Feature Gate Proposals (transactions are submited on-chain)",
             "Exit",
         ];
 

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -1,11 +1,11 @@
 use crate::commands::{
-    approve_feature_gate_activation_proposal, approve_feature_gate_activation_revocation_proposal, config_command, create_command, execute_feature_gate_activation_proposal, show_command
+    approve_feature_gate_activation_proposal, approve_feature_gate_activation_revocation_proposal,
+    config_command, create_command, execute_feature_gate_activation_proposal, show_command,
 };
 use crate::squads::get_vault_pda;
 use crate::utils::*;
 use eyre::Result;
 use inquire::{Confirm, Select, Text};
-use solana_pubkey::Pubkey;
 
 pub async fn interactive_mode() -> Result<()> {
     let mut config = load_config()?;

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -1,6 +1,7 @@
 use crate::commands::{
     approve_feature_gate_activation_proposal, approve_feature_gate_activation_revocation_proposal,
-    config_command, create_command, execute_feature_gate_activation_proposal, show_command,
+    config_command, create_command, execute_feature_gate_activation_proposal,
+    execute_feature_gate_revocation_proposal, show_command,
 };
 use crate::squads::get_vault_pda;
 use crate::utils::*;
@@ -36,6 +37,7 @@ pub async fn interactive_mode() -> Result<()> {
                     "Approve feature gate activation proposal",
                     "Approve feature gate activation revocation proposal",
                     "Execute feature gate activation proposal",
+                    "Execute feature gate revocation proposal",
                     "Exit",
                 ];
                 let choice: &str = Select::new("What would you like to do?", options).prompt()?;
@@ -89,6 +91,25 @@ pub async fn interactive_mode() -> Result<()> {
                             "Enter the voting key: (Can be either EOA or parent multisig)",
                         )?;
                         execute_feature_gate_activation_proposal(
+                            &config,
+                            feature_gate_multisig_address,
+                            voting_key,
+                            fee_payer_path,
+                            None,
+                        )
+                        .await?;
+                    }
+                    "Execute feature gate revocation proposal" => {
+                        Confirm::new(&format!(
+                            "You're executing the activation of the following feature gate: {}?",
+                            feature_gate_id
+                        ))
+                        .with_default(true)
+                        .prompt()?;
+                        let voting_key = prompt_for_pubkey(
+                            "Enter the voting key: (Can be either EOA or parent multisig)",
+                        )?;
+                        execute_feature_gate_revocation_proposal(
                             &config,
                             feature_gate_multisig_address,
                             voting_key,

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -29,7 +29,7 @@ pub async fn interactive_mode() -> Result<()> {
                 let feepayer_path = prompt_for_fee_payer_path(&config)?;
                 create_command(&mut config, None, vec![], Some(feepayer_path)).await?;
             }
-            "Approve/Execute Feature Gate Proposals" => {
+            "Approve/Execute Feature Gate Proposals (transactions are submited on-chain)" => {
                 let feature_gate_multisig_address =
                     prompt_for_pubkey("Enter the feature gate multisig address:")?;
                 let feature_gate_id = get_vault_pda(&feature_gate_multisig_address, 0, None).0;

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -1,24 +1,29 @@
-use colored::Colorize;
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use eyre::Result;
-use serde::Serialize;
-use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
+use solana_commitment_config::CommitmentConfig;
 use solana_message::VersionedMessage;
 use solana_pubkey::Pubkey;
-use solana_signature::Signature;
 use solana_signer::Signer;
 use solana_transaction::versioned::VersionedTransaction;
-use std::str::FromStr;
+use tokio::time::{sleep, Duration};
 
+use crate::squads::{get_vault_pda, Multisig as SquadsMultisig};
 use crate::{
     output,
     provision::{
-        create_approve_activation_revocation_transaction_message, create_approve_activation_transaction_message, create_execute_activation_transaction_message
+        create_approve_activation_revocation_transaction_message,
+        create_approve_activation_transaction_message, create_execute_transaction_message,
+        create_parent_approve_proposal_message, create_rpc_client,
+        create_transaction_and_proposal_message, get_proposal_status_and_threshold,
     },
     utils::{
-        choose_network_from_config, choose_transaction_encoding, load_fee_payer_keypair, Config,
-        TransactionEncoding,
+        choose_network_from_config, create_child_vote_approve_transaction_message,
+        load_fee_payer_keypair, Config,
     },
 };
+use borsh::BorshDeserialize;
+use inquire::Confirm;
 
 pub async fn approve_feature_gate_activation_proposal(
     config: &Config,
@@ -32,8 +37,208 @@ pub async fn approve_feature_gate_activation_proposal(
 
     let fee_payer_keypair = load_fee_payer_keypair(config, Some(fee_payer_path))?;
     let rpc_url = choose_network_from_config(config)?;
-    let rpc_client = RpcClient::new(rpc_url);
-    let blockhash = rpc_client.get_latest_blockhash().await?;
+    let rpc_client = create_rpc_client(&rpc_url);
+    let blockhash = rpc_client.get_latest_blockhash()?;
+
+    // Detect if voting_key is itself a Squads multisig (parent)
+    let is_parent_multisig = rpc_client
+        .get_account(&voting_key)
+        .ok()
+        .and_then(|acc| {
+            if acc.data.len() >= 8 {
+                let slice = &acc.data[8..];
+                SquadsMultisig::deserialize(&mut &slice[..]).ok()
+            } else {
+                None
+            }
+        })
+        .is_some();
+
+    if is_parent_multisig {
+        // Create a parent multisig transaction+proposal that will cast the vote on the child (activation = tx index 1)
+        let parent_multisig = voting_key;
+
+        // Fetch parent's next transaction index
+        let parent_acc = rpc_client
+            .get_account(&parent_multisig)
+            .map_err(|e| eyre::eyre!("Failed to fetch parent multisig account: {}", e))?;
+        let parent_ms: SquadsMultisig =
+            BorshDeserialize::deserialize(&mut &parent_acc.data[8..])
+                .map_err(|e| eyre::eyre!("Failed to deserialize parent multisig: {}", e))?;
+        let parent_next_index = parent_ms.transaction_index + 1;
+
+        // Prefer using the parent vault PDA as the child member so the parent program can sign via seeds.
+        let parent_vault_member = get_vault_pda(&parent_multisig, 0, None).0;
+
+        // Validate the child multisig includes the parent vault PDA with Vote permission
+        let child_acc = rpc_client
+            .get_account(&feature_gate_multisig_address)
+            .map_err(|e| eyre::eyre!("Failed to fetch child multisig: {}", e))?;
+        let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
+            .map_err(|e| eyre::eyre!("Failed to deserialize child multisig: {}", e))?;
+        let parent_vault_is_member_with_vote = child_ms
+            .members
+            .iter()
+            .any(|m| m.key == parent_vault_member && (m.permissions.mask & (1 << 1)) != 0);
+
+        if !parent_vault_is_member_with_vote {
+            // Helpful diagnostic: detect if the parent multisig address itself is a member (common misconfig)
+            let parent_multisig_is_member =
+                child_ms.members.iter().any(|m| m.key == parent_multisig);
+            if parent_multisig_is_member {
+                output::Output::error("Child multisig has the parent multisig address as a member, but not the parent vault PDA. The parent program cannot sign as the multisig address during CPI.");
+                output::Output::hint(&format!(
+                    "Please add the parent vault PDA as a member with Vote permission on the child: {}",
+                    parent_vault_member
+                ));
+            } else {
+                output::Output::error("Child multisig is missing the parent vault PDA as a member with Vote permission.");
+                output::Output::hint(&format!(
+                    "Add this key as a member with Vote: {}",
+                    parent_vault_member
+                ));
+            }
+            return Err(eyre::eyre!(
+                "Child multisig missing required member for programmatic approval"
+            ));
+        }
+
+        let tx_message = create_child_vote_approve_transaction_message(
+            feature_gate_multisig_address,
+            1,
+            parent_vault_member,
+        );
+
+        let (msg, tx_pda, prop_pda) = create_transaction_and_proposal_message(
+            None,
+            &fee_payer_keypair.as_ref().unwrap().pubkey(),
+            &fee_payer_keypair.as_ref().unwrap().pubkey(),
+            &parent_multisig,
+            parent_next_index,
+            0,
+            tx_message,
+            Some(5000),
+            Some(crate::constants::DEFAULT_COMPUTE_UNITS),
+            blockhash,
+        )?;
+        output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
+        output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
+
+        let fee_payer_signer = fee_payer_keypair.as_ref().unwrap();
+        let transaction = VersionedTransaction::try_new(
+            VersionedMessage::V0(msg),
+            &[fee_payer_signer as &dyn Signer],
+        )?;
+        let signature =
+            crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+                .map_err(|e| eyre::eyre!("Failed to send parent vote transaction: {}", e))?;
+
+        output::Output::header("Parent Multisig Vote Transaction Created & Sent:");
+        output::Output::field("Signature:", &signature);
+
+        // Offer to approve the parent proposal immediately (casts one Approve vote)
+        if Confirm::new("Approve this parent proposal now?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+        {
+            let parent_proposal_index = parent_next_index;
+            let approve_msg = create_parent_approve_proposal_message(
+                &program_id,
+                &parent_multisig,
+                &fee_payer_keypair.as_ref().unwrap().pubkey(),
+                &fee_payer_keypair.as_ref().unwrap().pubkey(),
+                parent_proposal_index,
+                blockhash,
+            )?;
+            let approve_tx = VersionedTransaction::try_new(
+                VersionedMessage::V0(approve_msg),
+                &[fee_payer_signer as &dyn Signer],
+            )?;
+            let approve_sig =
+                crate::provision::send_and_confirm_transaction(&approve_tx, &rpc_client)
+                    .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
+            output::Output::field("Parent proposal approved (sig):", &approve_sig);
+
+            // If approvals meet threshold, offer to execute the parent proposal now
+            let async_client =
+                AsyncRpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
+            let (approved, threshold, _status) = get_proposal_status_and_threshold(
+                &program_id,
+                &parent_multisig,
+                parent_proposal_index,
+                &async_client,
+            )
+            .await?;
+            let is_fee_payer_member = parent_ms
+                .members
+                .iter()
+                .any(|m| m.key == fee_payer_signer.pubkey());
+            // Ensure executor has Execute permission on parent multisig
+            let has_execute_permission = parent_ms
+                .members
+                .iter()
+                .find(|m| m.key == fee_payer_signer.pubkey())
+                .map(|m| (m.permissions.mask & (1 << 2)) != 0)
+                .unwrap_or(false);
+
+            if approved as u16 >= threshold && is_fee_payer_member && has_execute_permission {
+                if Confirm::new("Execute this parent proposal now?")
+                    .with_default(true)
+                    .prompt()
+                    .unwrap_or(false)
+                {
+                    // Briefly poll until status reflects approval on-chain to avoid races
+                    let mut tries = 0;
+                    while tries < 10 {
+                        let (appr, _th, _st) = get_proposal_status_and_threshold(
+                            &program_id,
+                            &parent_multisig,
+                            parent_proposal_index,
+                            &async_client,
+                        )
+                        .await?;
+                        if appr as u16 >= threshold {
+                            break;
+                        }
+                        sleep(Duration::from_millis(400)).await;
+                        tries += 1;
+                    }
+
+                    // Refresh blockhash before building execute tx
+                    let fresh_blockhash = async_client.get_latest_blockhash().await?;
+                    let exec_msg = create_execute_transaction_message(
+                        &program_id,
+                        &parent_multisig,
+                        &fee_payer_signer.pubkey(),
+                        &fee_payer_signer.pubkey(),
+                        parent_proposal_index,
+                        &async_client,
+                        fresh_blockhash,
+                    )
+                    .await?;
+                    let exec_tx = VersionedTransaction::try_new(
+                        VersionedMessage::V0(exec_msg),
+                        &[fee_payer_signer as &dyn Signer],
+                    )?;
+                    let exec_sig =
+                        crate::provision::send_and_confirm_transaction(&exec_tx, &rpc_client)
+                            .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
+                    output::Output::field("Parent proposal executed (sig):", &exec_sig);
+                }
+            } else if !is_fee_payer_member {
+                output::Output::hint("Fee payer is not a member of the parent multisig; cannot auto-execute. Use a parent member as the executor.");
+            } else if !has_execute_permission {
+                output::Output::hint("Executor does not have Execute permission on the parent multisig; use a member with Execute to run execution.");
+            } else {
+                output::Output::hint(&format!(
+                    "Parent approvals {}/{} — waiting for more confirmations before execution.",
+                    approved, threshold
+                ));
+            }
+        }
+        return Ok(());
+    }
 
     let transaction_message = create_approve_activation_transaction_message(
         &program_id,
@@ -49,21 +254,26 @@ pub async fn approve_feature_gate_activation_proposal(
         )
     })?;
 
-    let mut transaction = VersionedTransaction::try_new(
+    let transaction = VersionedTransaction::try_new(
         VersionedMessage::V0(transaction_message),
         &[&fee_payer_keypair.unwrap()],
     )?;
-    transaction.signatures.push(Signature::default());
     let serialized_transaction = bincode::serialize(&transaction)?;
 
     let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = base64::encode(&serialized_transaction);
+    let transaction_encoded_base64 = B64.encode(&serialized_transaction);
 
     output::Output::header("Encoded Transactions:");
     output::Output::separator();
     output::Output::field("Base58:", &transaction_encoded_bs58);
     output::Output::separator();
     output::Output::field("Base64:", &transaction_encoded_base64);
+    output::Output::separator();
+
+    // Optional: also send it now and print signature
+    let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+        .map_err(|e| eyre::eyre!("Failed to send transaction and proposal: {}", e))?;
+    output::Output::field("Transaction sent successfully:", &signature);
     Ok(())
 }
 
@@ -79,8 +289,202 @@ pub async fn approve_feature_gate_activation_revocation_proposal(
 
     let fee_payer_keypair = load_fee_payer_keypair(config, Some(fee_payer_path))?;
     let rpc_url = choose_network_from_config(config)?;
-    let rpc_client = RpcClient::new(rpc_url);
-    let blockhash = rpc_client.get_latest_blockhash().await?;
+    let rpc_client = create_rpc_client(&rpc_url);
+    let blockhash = rpc_client
+        .get_latest_blockhash()
+        .map_err(|e| eyre::eyre!("Failed to get recent blockhash: {}", e))?;
+
+    // Detect if voting_key is a Squads multisig (parent) for revocation path
+    let is_parent_multisig = rpc_client
+        .get_account(&voting_key)
+        .ok()
+        .and_then(|acc| {
+            if acc.data.len() >= 8 {
+                let slice = &acc.data[8..];
+                SquadsMultisig::deserialize(&mut &slice[..]).ok()
+            } else {
+                None
+            }
+        })
+        .is_some();
+
+    if is_parent_multisig {
+        let parent_multisig = voting_key;
+        let parent_acc = rpc_client
+            .get_account(&parent_multisig)
+            .map_err(|e| eyre::eyre!("Failed to fetch parent multisig account: {}", e))?;
+        let parent_ms: SquadsMultisig =
+            BorshDeserialize::deserialize(&mut &parent_acc.data[8..])
+                .map_err(|e| eyre::eyre!("Failed to deserialize parent multisig: {}", e))?;
+        let parent_next_index = parent_ms.transaction_index + 1;
+
+        let parent_vault_member = get_vault_pda(&parent_multisig, 0, None).0;
+
+        // Validate child membership for parent vault PDA with Vote permission
+        let child_acc = rpc_client
+            .get_account(&feature_gate_multisig_address)
+            .map_err(|e| eyre::eyre!("Failed to fetch child multisig: {}", e))?;
+        let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
+            .map_err(|e| eyre::eyre!("Failed to deserialize child multisig: {}", e))?;
+        let parent_vault_is_member_with_vote = child_ms
+            .members
+            .iter()
+            .any(|m| m.key == parent_vault_member && (m.permissions.mask & (1 << 1)) != 0);
+
+        if !parent_vault_is_member_with_vote {
+            let parent_multisig_is_member =
+                child_ms.members.iter().any(|m| m.key == parent_multisig);
+            if parent_multisig_is_member {
+                output::Output::error("Child multisig has the parent multisig address as a member, but not the parent vault PDA. The parent program cannot sign as the multisig address during CPI.");
+                output::Output::hint(&format!(
+                    "Please add the parent vault PDA as a member with Vote permission on the child: {}",
+                    parent_vault_member
+                ));
+            } else {
+                output::Output::error("Child multisig is missing the parent vault PDA as a member with Vote permission.");
+                output::Output::hint(&format!(
+                    "Add this key as a member with Vote: {}",
+                    parent_vault_member
+                ));
+            }
+            return Err(eyre::eyre!(
+                "Child multisig missing required member for programmatic approval"
+            ));
+        }
+
+        let tx_message = create_child_vote_approve_transaction_message(
+            feature_gate_multisig_address,
+            2,
+            parent_vault_member,
+        );
+
+        let (msg, tx_pda, prop_pda) = create_transaction_and_proposal_message(
+            None,
+            &fee_payer_keypair.as_ref().unwrap().pubkey(),
+            &fee_payer_keypair.as_ref().unwrap().pubkey(),
+            &parent_multisig,
+            parent_next_index,
+            0,
+            tx_message,
+            Some(5000),
+            Some(crate::constants::DEFAULT_COMPUTE_UNITS),
+            blockhash,
+        )?;
+        output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
+        output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
+
+        let fee_payer_signer = fee_payer_keypair.as_ref().unwrap();
+        let transaction = VersionedTransaction::try_new(
+            VersionedMessage::V0(msg),
+            &[fee_payer_signer as &dyn Signer],
+        )?;
+        let signature =
+            crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+                .map_err(|e| eyre::eyre!("Failed to send parent vote transaction: {}", e))?;
+
+        output::Output::header("Parent Multisig Vote Transaction Created & Sent:");
+        output::Output::field("Signature:", &signature);
+
+        if Confirm::new("Approve this parent proposal now?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+        {
+            let parent_proposal_index = parent_next_index;
+            let approve_msg = create_parent_approve_proposal_message(
+                &program_id,
+                &parent_multisig,
+                &fee_payer_keypair.as_ref().unwrap().pubkey(),
+                &fee_payer_keypair.as_ref().unwrap().pubkey(),
+                parent_proposal_index,
+                blockhash,
+            )?;
+            let approve_tx = VersionedTransaction::try_new(
+                VersionedMessage::V0(approve_msg),
+                &[fee_payer_signer as &dyn Signer],
+            )?;
+            let approve_sig =
+                crate::provision::send_and_confirm_transaction(&approve_tx, &rpc_client)
+                    .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
+            output::Output::field("Parent proposal approved (sig):", &approve_sig);
+
+            // If approvals meet threshold, offer to execute the parent proposal now
+            let async_client =
+                AsyncRpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
+            let (approved, threshold, _status) = get_proposal_status_and_threshold(
+                &program_id,
+                &parent_multisig,
+                parent_proposal_index,
+                &async_client,
+            )
+            .await?;
+            let is_fee_payer_member = parent_ms
+                .members
+                .iter()
+                .any(|m| m.key == fee_payer_signer.pubkey());
+            let has_execute_permission = parent_ms
+                .members
+                .iter()
+                .find(|m| m.key == fee_payer_signer.pubkey())
+                .map(|m| (m.permissions.mask & (1 << 2)) != 0)
+                .unwrap_or(false);
+
+            if approved as u16 >= threshold && is_fee_payer_member && has_execute_permission {
+                if Confirm::new("Execute this parent proposal now?")
+                    .with_default(true)
+                    .prompt()
+                    .unwrap_or(false)
+                {
+                    // Briefly poll until status reflects approval on-chain
+                    let mut tries = 0;
+                    while tries < 10 {
+                        let (appr, _th, _st) = get_proposal_status_and_threshold(
+                            &program_id,
+                            &parent_multisig,
+                            parent_proposal_index,
+                            &async_client,
+                        )
+                        .await?;
+                        if appr as u16 >= threshold {
+                            break;
+                        }
+                        sleep(Duration::from_millis(400)).await;
+                        tries += 1;
+                    }
+
+                    let fresh_blockhash = async_client.get_latest_blockhash().await?;
+                    let exec_msg = create_execute_transaction_message(
+                        &program_id,
+                        &parent_multisig,
+                        &fee_payer_signer.pubkey(),
+                        &fee_payer_signer.pubkey(),
+                        parent_proposal_index,
+                        &async_client,
+                        fresh_blockhash,
+                    )
+                    .await?;
+                    let exec_tx = VersionedTransaction::try_new(
+                        VersionedMessage::V0(exec_msg),
+                        &[fee_payer_signer as &dyn Signer],
+                    )?;
+                    let exec_sig =
+                        crate::provision::send_and_confirm_transaction(&exec_tx, &rpc_client)
+                            .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
+                    output::Output::field("Parent proposal executed (sig):", &exec_sig);
+                }
+            } else if !is_fee_payer_member {
+                output::Output::hint("Fee payer is not a member of the parent multisig; cannot auto-execute. Use a parent member as the executor.");
+            } else if !has_execute_permission {
+                output::Output::hint("Executor does not have Execute permission on the parent multisig; use a member with Execute to run execution.");
+            } else {
+                output::Output::hint(&format!(
+                    "Parent approvals {}/{} — waiting for more confirmations before execution.",
+                    approved, threshold
+                ));
+            }
+        }
+        return Ok(());
+    }
 
     let transaction_message = create_approve_activation_revocation_transaction_message(
         &program_id,
@@ -96,23 +500,29 @@ pub async fn approve_feature_gate_activation_revocation_proposal(
         )
     })?;
 
-    let mut transaction = VersionedTransaction::try_new(
+    let transaction = VersionedTransaction::try_new(
         VersionedMessage::V0(transaction_message),
         &[&fee_payer_keypair.unwrap()],
     )?;
-    transaction.signatures.push(Signature::default());
+
     let serialized_transaction = bincode::serialize(&transaction)?;
 
     let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = base64::encode(&serialized_transaction);
+    let transaction_encoded_base64 = B64.encode(&serialized_transaction);
 
     output::Output::header("Encoded Transactions:");
     output::Output::separator();
     output::Output::field("Base58:", &transaction_encoded_bs58);
     output::Output::separator();
     output::Output::field("Base64:", &transaction_encoded_base64);
+
+    let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+        .map_err(|e| eyre::eyre!("Failed to send transaction and proposal: {}", e))?;
+    output::Output::separator();
+    output::Output::field("Transaction sent successfully:", &signature);
     Ok(())
 }
+
 pub async fn execute_feature_gate_activation_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
@@ -125,32 +535,69 @@ pub async fn execute_feature_gate_activation_proposal(
 
     let fee_payer_keypair = load_fee_payer_keypair(config, Some(fee_payer_path))?;
     let rpc_url = choose_network_from_config(config)?;
-    let rpc_client = RpcClient::new(rpc_url);
-    let blockhash = rpc_client.get_latest_blockhash().await?;
+    // Non-blocking client for data fetches, blocking for simulate/send
+    let async_client = AsyncRpcClient::new(rpc_url.clone());
+    let rpc_client = create_rpc_client(&rpc_url);
 
-    let transaction_message = create_execute_activation_transaction_message(
+    // Readiness check: ensure approvals >= threshold on child proposal index 1
+    let (approved, threshold, _status) = get_proposal_status_and_threshold(
+        &program_id,
+        &feature_gate_multisig_address,
+        1,
+        &async_client,
+    )
+    .await?;
+    if (approved as u16) < threshold {
+        output::Output::hint(&format!(
+            "Proposal not ready to execute yet: approvals {}/{}",
+            approved, threshold
+        ));
+        return Err(eyre::eyre!("Insufficient approvals to execute"));
+    }
+
+    // Permission check: voting_key must be a member with Execute permission on the child multisig
+    let child_acc = rpc_client
+        .get_account(&feature_gate_multisig_address)
+        .map_err(|e| eyre::eyre!("Failed to fetch multisig account: {}", e))?;
+    let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
+        .map_err(|e| eyre::eyre!("Failed to deserialize multisig: {}", e))?;
+    let is_member = child_ms.members.iter().any(|m| m.key == voting_key);
+    let has_execute = child_ms
+        .members
+        .iter()
+        .find(|m| m.key == voting_key)
+        .map(|m| (m.permissions.mask & (1 << 2)) != 0)
+        .unwrap_or(false);
+    if !is_member {
+        output::Output::error("Executor key is not a member of the multisig.");
+        return Err(eyre::eyre!("Executor must be a multisig member"));
+    }
+    if !has_execute {
+        output::Output::error("Executor key does not have Execute permission.");
+        return Err(eyre::eyre!("Missing Execute permission for executor"));
+    }
+
+    // Fresh blockhash and build execute message for proposal index 1
+    let blockhash = async_client.get_latest_blockhash().await?;
+    let exec_msg = create_execute_transaction_message(
         &program_id,
         &feature_gate_multisig_address,
         &voting_key,
         &fee_payer_keypair.as_ref().unwrap().pubkey(),
-        &rpc_client,
+        1,
+        &async_client,
         blockhash,
     )
     .await?;
 
     let transaction = VersionedTransaction::try_new(
-        VersionedMessage::V0(transaction_message),
-        &[&fee_payer_keypair.unwrap()],
+        VersionedMessage::V0(exec_msg),
+        &[&fee_payer_keypair.as_ref().unwrap()],
     )?;
-    let serialized_transaction = bincode::serialize(&transaction)?;
 
-    output::Output::header("Encoded Transactions:");
-
-    let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = base64::encode(&serialized_transaction);
-
-    output::Output::field("Base58:", &transaction_encoded_bs58);
-    output::Output::field("Base64:", &transaction_encoded_base64);
-
+    // Send and confirm
+    let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+        .map_err(|e| eyre::eyre!("Failed to execute proposal: {}", e))?;
+    output::Output::field("Proposal executed (sig):", &signature);
     Ok(())
 }

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use eyre::Result;
 use solana_clap_v3_utils::keypair::signer_from_path;
 use solana_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
@@ -16,10 +15,7 @@ use crate::{
         create_parent_approve_proposal_message, create_rpc_client,
         create_transaction_and_proposal_message, get_proposal_status_and_threshold,
     },
-    utils::{
-        choose_network_from_config, create_child_vote_approve_transaction_message,
-        load_fee_payer_keypair, Config,
-    },
+    utils::{choose_network_from_config, create_child_vote_approve_transaction_message, Config},
 };
 use borsh::BorshDeserialize;
 use inquire::Confirm;
@@ -309,17 +305,6 @@ pub async fn approve_common_feature_gate_proposal(
         VersionedMessage::V0(transaction_message),
         &[fee_payer_signer.as_ref()],
     )?;
-    let serialized_transaction = bincode::serialize(&transaction)?;
-
-    let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = B64.encode(&serialized_transaction);
-
-    output::Output::header("Encoded Transactions:");
-    output::Output::separator();
-    output::Output::field("Base58:", &transaction_encoded_bs58);
-    output::Output::separator();
-    output::Output::field("Base64:", &transaction_encoded_base64);
-    output::Output::separator();
 
     // Confirm before sending on-chain (EOA approval path)
     let should_send = Confirm::new("Send this approve transaction now?")
@@ -453,17 +438,6 @@ pub async fn execute_common_feature_gate_proposal(
         VersionedMessage::V0(exec_msg),
         &[fee_payer_signer.as_ref()],
     )?;
-
-    let serialized_transaction = bincode::serialize(&transaction)?;
-
-    let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = B64.encode(&serialized_transaction);
-
-    output::Output::header("Encoded Transactions:");
-    output::Output::separator();
-    output::Output::field("Base58:", &transaction_encoded_bs58);
-    output::Output::separator();
-    output::Output::field("Base64:", &transaction_encoded_base64);
 
     // Confirm before sending on-chain (EOA execute path)
     let should_send = Confirm::new("Send this execute transaction now?")

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -1,7 +1,5 @@
 use eyre::Result;
 use solana_clap_v3_utils::keypair::signer_from_path;
-use solana_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
-use solana_commitment_config::CommitmentConfig;
 use solana_message::VersionedMessage;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
@@ -11,14 +9,303 @@ use crate::squads::{get_vault_pda, Multisig as SquadsMultisig};
 use crate::{
     output,
     provision::{
-        create_common_activation_transaction_message, create_execute_transaction_message,
-        create_parent_approve_proposal_message, create_rpc_client,
-        create_transaction_and_proposal_message, get_proposal_status_and_threshold,
+        create_child_execute_transaction_message, create_common_activation_transaction_message,
+        create_execute_transaction_message, create_parent_approve_proposal_message,
+        create_rpc_client, create_transaction_and_proposal_message,
+        get_proposal_status_and_threshold,
     },
     utils::{choose_network_from_config, create_child_vote_approve_transaction_message, Config},
 };
 use borsh::BorshDeserialize;
 use inquire::Confirm;
+
+/// Helper enum to specify the type of parent multisig operation
+#[derive(Debug, Clone)]
+enum ParentMultisigOperation {
+    Approve,
+    Execute,
+}
+
+/// Common flow for creating and optionally executing a parent multisig proposal
+/// that operates on a child multisig.
+///
+/// This handles:
+/// - Validating parent vault PDA has required permissions on child
+/// - Creating parent transaction+proposal
+/// - Optionally approving the parent proposal
+/// - Optionally executing the parent proposal (if threshold met)
+async fn handle_parent_multisig_flow(
+    program_id: &Pubkey,
+    parent_multisig: Pubkey,
+    feature_gate_multisig_address: Pubkey,
+    activation_or_revocation: u64,
+    fee_payer_signer: &Box<dyn Signer>,
+    rpc_url: &str,
+    operation: ParentMultisigOperation,
+    execution_accounts: Option<Vec<solana_instruction::AccountMeta>>,
+) -> Result<()> {
+    let rpc_client = create_rpc_client(rpc_url);
+
+    // Fetch parent's next transaction index
+    let parent_acc = rpc_client
+        .get_account(&parent_multisig)
+        .map_err(|e| eyre::eyre!("Failed to fetch parent multisig account: {}", e))?;
+    let parent_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &parent_acc.data[8..])
+        .map_err(|e| eyre::eyre!("Failed to deserialize parent multisig: {}", e))?;
+    let parent_next_index = parent_ms.transaction_index + 1;
+
+    // The fee payer must be a member of the parent multisig to initiate proposals
+    let fee_payer_is_member = parent_ms
+        .members
+        .iter()
+        .any(|m| m.key == fee_payer_signer.pubkey());
+    if !fee_payer_is_member {
+        output::Output::error(
+            "Fee payer must be a member of the parent multisig to create/approve/execute proposals.",
+        );
+        output::Output::hint(&format!(
+            "Current fee payer: {}\nParent multisig: {}\nAdd the fee payer as a member (with {} permission) or choose a fee payer that is already a member.",
+            fee_payer_signer.pubkey(),
+            parent_multisig,
+            match operation {
+                ParentMultisigOperation::Approve => "Vote",
+                ParentMultisigOperation::Execute => "Execute",
+            }
+        ));
+        return Err(eyre::eyre!(
+            "Fee payer is not a member of the parent multisig"
+        ));
+    }
+
+    // Prefer using the parent vault PDA as the child member
+    let parent_vault_member = get_vault_pda(&parent_multisig, 0, None).0;
+
+    // Validate the child multisig includes the parent vault PDA with required permission
+    let child_acc = rpc_client
+        .get_account(&feature_gate_multisig_address)
+        .map_err(|e| eyre::eyre!("Failed to fetch child multisig: {}", e))?;
+    let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
+        .map_err(|e| eyre::eyre!("Failed to deserialize child multisig: {}", e))?;
+
+    // Check required permission based on operation type
+    let (required_permission_mask, permission_name, action_description) = match &operation {
+        ParentMultisigOperation::Approve => (
+            1 << 1, // Vote permission
+            "Vote",
+            if activation_or_revocation == 1 {
+                "Approve Feature Gate Activation"
+            } else {
+                "Approve Feature Gate Revocation"
+            },
+        ),
+        ParentMultisigOperation::Execute => (
+            1 << 2, // Execute permission
+            "Execute",
+            if activation_or_revocation == 1 {
+                "Execute Feature Gate Activation"
+            } else {
+                "Execute Feature Gate Revocation"
+            },
+        ),
+    };
+
+    let parent_vault_has_permission = child_ms.members.iter().any(|m| {
+        m.key == parent_vault_member && (m.permissions.mask & required_permission_mask) != 0
+    });
+
+    if !parent_vault_has_permission {
+        let parent_multisig_is_member = child_ms.members.iter().any(|m| m.key == parent_multisig);
+        if parent_multisig_is_member {
+            output::Output::error(&format!(
+                "Child multisig has the parent multisig address as a member, but not the parent vault PDA. The parent program cannot sign as the multisig address during CPI."
+            ));
+            output::Output::hint(&format!(
+                "Please add the parent vault PDA as a member with {} permission on the child: {}",
+                permission_name, parent_vault_member
+            ));
+        } else {
+            output::Output::error(&format!(
+                "Child multisig is missing the parent vault PDA as a member with {} permission.",
+                permission_name
+            ));
+            output::Output::hint(&format!(
+                "Add this key as a member with {}: {}",
+                permission_name, parent_vault_member
+            ));
+        }
+        return Err(eyre::eyre!(
+            "Child multisig missing required member for programmatic {}",
+            permission_name.to_lowercase()
+        ));
+    }
+
+    // Display information about the parent multisig transaction
+    output::Output::header(&format!(
+        "Parent Multisig {} Transaction Details:",
+        permission_name
+    ));
+    output::Output::field("Parent Multisig:", &parent_multisig.to_string());
+    output::Output::field(
+        "Child Multisig:",
+        &feature_gate_multisig_address.to_string(),
+    );
+    output::Output::field("Parent Transaction Index:", &parent_next_index.to_string());
+    if matches!(operation, ParentMultisigOperation::Execute) {
+        output::Output::field(
+            "Child Transaction Index:",
+            &activation_or_revocation.to_string(),
+        );
+    }
+    output::Output::field("Action:", action_description);
+
+    // Ask for confirmation before creating the parent multisig proposal
+    let confirmation_prompt = match &operation {
+        ParentMultisigOperation::Approve => "Create parent multisig proposal for this transaction?",
+        ParentMultisigOperation::Execute => {
+            "Create parent multisig proposal to execute child transaction?"
+        }
+    };
+
+    if !Confirm::new(confirmation_prompt)
+        .with_default(true)
+        .prompt()
+        .unwrap_or(false)
+    {
+        output::Output::info("Parent multisig proposal creation cancelled.");
+        return Ok(());
+    }
+
+    // Create the transaction message based on operation type
+    let tx_message = match operation {
+        ParentMultisigOperation::Approve => create_child_vote_approve_transaction_message(
+            feature_gate_multisig_address,
+            activation_or_revocation,
+            parent_vault_member,
+        ),
+        ParentMultisigOperation::Execute => create_child_execute_transaction_message(
+            feature_gate_multisig_address,
+            activation_or_revocation,
+            parent_vault_member,
+            execution_accounts
+                .ok_or_else(|| eyre::eyre!("Execution accounts required for Execute operation"))?,
+        ),
+    };
+
+    let blockhash = rpc_client.get_latest_blockhash()?;
+    let (msg, tx_pda, prop_pda) = create_transaction_and_proposal_message(
+        None,
+        &fee_payer_signer.pubkey(),
+        &fee_payer_signer.pubkey(),
+        &parent_multisig,
+        parent_next_index,
+        0,
+        tx_message,
+        Some(5000),
+        Some(crate::constants::DEFAULT_COMPUTE_UNITS),
+        blockhash,
+    )?;
+    output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
+    output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
+
+    let transaction =
+        VersionedTransaction::try_new(VersionedMessage::V0(msg), &[fee_payer_signer.as_ref()])?;
+    let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
+        .map_err(|e| eyre::eyre!("Failed to send parent transaction: {}", e))?;
+
+    output::Output::header(&format!(
+        "Parent Multisig {} Transaction Created & Sent:",
+        permission_name
+    ));
+    output::Output::field("Signature:", &signature);
+
+    // Offer to approve the parent proposal immediately
+    if Confirm::new("Approve this parent proposal now?")
+        .with_default(true)
+        .prompt()
+        .unwrap_or(false)
+    {
+        let parent_proposal_index = parent_next_index;
+        let approve_msg = create_parent_approve_proposal_message(
+            program_id,
+            &parent_multisig,
+            &fee_payer_signer.pubkey(),
+            &fee_payer_signer.pubkey(),
+            parent_proposal_index,
+            blockhash,
+        )?;
+        let approve_tx = VersionedTransaction::try_new(
+            VersionedMessage::V0(approve_msg),
+            &[fee_payer_signer.as_ref()],
+        )?;
+        let approve_sig = crate::provision::send_and_confirm_transaction(&approve_tx, &rpc_client)
+            .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
+        output::Output::field("Parent proposal approved (sig):", &approve_sig);
+
+        // If approvals meet threshold, offer to execute the parent proposal now
+        let (approved, threshold, _status) = get_proposal_status_and_threshold(
+            program_id,
+            &parent_multisig,
+            parent_proposal_index,
+            &rpc_client,
+        )?;
+        let is_fee_payer_member = parent_ms
+            .members
+            .iter()
+            .any(|m| m.key == fee_payer_signer.pubkey());
+        let has_execute_permission = parent_ms
+            .members
+            .iter()
+            .find(|m| m.key == fee_payer_signer.pubkey())
+            .map(|m| (m.permissions.mask & (1 << 2)) != 0)
+            .unwrap_or(false);
+
+        if approved as u16 >= threshold && is_fee_payer_member && has_execute_permission {
+            if Confirm::new("Execute this parent proposal now?")
+                .with_default(true)
+                .prompt()
+                .unwrap_or(false)
+            {
+                let fresh_blockhash = rpc_client.get_latest_blockhash()?;
+                let exec_msg = create_execute_transaction_message(
+                    program_id,
+                    &parent_multisig,
+                    &fee_payer_signer.pubkey(),
+                    &fee_payer_signer.pubkey(),
+                    parent_proposal_index,
+                    &rpc_client,
+                    fresh_blockhash,
+                )?;
+                let exec_tx = VersionedTransaction::try_new(
+                    VersionedMessage::V0(exec_msg),
+                    &[fee_payer_signer.as_ref()],
+                )?;
+                let exec_sig =
+                    crate::provision::send_and_confirm_transaction(&exec_tx, &rpc_client)
+                        .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
+                output::Output::field("Parent proposal executed (sig):", &exec_sig);
+                if matches!(operation, ParentMultisigOperation::Execute) {
+                    output::Output::success(
+                        "Child transaction has been executed via parent multisig!",
+                    );
+                }
+            }
+        } else if !is_fee_payer_member {
+            output::Output::hint(
+                "Fee payer is not a member of the parent multisig; cannot auto-execute.",
+            );
+        } else if !has_execute_permission {
+            output::Output::hint(
+                "Executor does not have Execute permission on the parent multisig.",
+            );
+        } else {
+            output::Output::hint(&format!(
+                "Parent approvals {}/{} — waiting for more confirmations before execution.",
+                approved, threshold
+            ));
+        }
+    }
+    Ok(())
+}
 
 pub async fn approve_feature_gate_activation_proposal(
     config: &Config,
@@ -51,7 +338,7 @@ pub async fn approve_feature_gate_activation_revocation_proposal(
         voting_key,
         fee_payer_path,
         program_id,
-        1, // activation
+        2, // revocation
     )
     .await
 }
@@ -94,196 +381,17 @@ pub async fn approve_common_feature_gate_proposal(
         .is_some();
 
     if is_parent_multisig {
-        // Create a parent multisig transaction+proposal that will cast the vote on the child (activation = tx index 1)
-        let parent_multisig = voting_key;
-
-        // Fetch parent's next transaction index
-        let parent_acc = rpc_client
-            .get_account(&parent_multisig)
-            .map_err(|e| eyre::eyre!("Failed to fetch parent multisig account: {}", e))?;
-        let parent_ms: SquadsMultisig =
-            BorshDeserialize::deserialize(&mut &parent_acc.data[8..])
-                .map_err(|e| eyre::eyre!("Failed to deserialize parent multisig: {}", e))?;
-        let parent_next_index = parent_ms.transaction_index + 1;
-
-        // Prefer using the parent vault PDA as the child member so the parent program can sign via seeds.
-        let parent_vault_member = get_vault_pda(&parent_multisig, 0, None).0;
-
-        // Validate the child multisig includes the parent vault PDA with Vote permission
-        let child_acc = rpc_client
-            .get_account(&feature_gate_multisig_address)
-            .map_err(|e| eyre::eyre!("Failed to fetch child multisig: {}", e))?;
-        let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
-            .map_err(|e| eyre::eyre!("Failed to deserialize child multisig: {}", e))?;
-        let parent_vault_is_member_with_vote = child_ms
-            .members
-            .iter()
-            .any(|m| m.key == parent_vault_member && (m.permissions.mask & (1 << 1)) != 0);
-
-        if !parent_vault_is_member_with_vote {
-            // Helpful diagnostic: detect if the parent multisig address itself is a member (common misconfig)
-            let parent_multisig_is_member =
-                child_ms.members.iter().any(|m| m.key == parent_multisig);
-            if parent_multisig_is_member {
-                output::Output::error("Child multisig has the parent multisig address as a member, but not the parent vault PDA. The parent program cannot sign as the multisig address during CPI.");
-                output::Output::hint(&format!(
-                    "Please add the parent vault PDA as a member with Vote permission on the child: {}",
-                    parent_vault_member
-                ));
-            } else {
-                output::Output::error("Child multisig is missing the parent vault PDA as a member with Vote permission.");
-                output::Output::hint(&format!(
-                    "Add this key as a member with Vote: {}",
-                    parent_vault_member
-                ));
-            }
-            return Err(eyre::eyre!(
-                "Child multisig missing required member for programmatic approval"
-            ));
-        }
-
-        // Display information about the parent multisig transaction that will be created
-        output::Output::header("Parent Multisig Transaction Details:");
-        output::Output::field("Parent Multisig:", &parent_multisig.to_string());
-        output::Output::field(
-            "Child Multisig:",
-            &feature_gate_multisig_address.to_string(),
-        );
-        output::Output::field("Transaction Index:", &parent_next_index.to_string());
-        output::Output::field(
-            "Action:",
-            if activation_or_revocation == 1 {
-                "Approve Feature Gate Activation"
-            } else {
-                "Approve Feature Gate Revocation"
-            },
-        );
-
-        // Ask for confirmation before creating the parent multisig proposal
-        if !Confirm::new("Create parent multisig proposal for this transaction?")
-            .with_default(true)
-            .prompt()
-            .unwrap_or(false)
-        {
-            output::Output::info("Parent multisig proposal creation cancelled.");
-            return Ok(());
-        }
-
-        let tx_message = create_child_vote_approve_transaction_message(
+        return handle_parent_multisig_flow(
+            &program_id,
+            voting_key,
             feature_gate_multisig_address,
             activation_or_revocation,
-            parent_vault_member,
-        );
-
-        let (msg, tx_pda, prop_pda) = create_transaction_and_proposal_message(
+            &fee_payer_signer,
+            &rpc_url,
+            ParentMultisigOperation::Approve,
             None,
-            &fee_payer_signer.pubkey(),
-            &fee_payer_signer.pubkey(),
-            &parent_multisig,
-            parent_next_index,
-            0,
-            tx_message,
-            Some(5000),
-            Some(crate::constants::DEFAULT_COMPUTE_UNITS),
-            blockhash,
-        )?;
-        output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
-        output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
-
-        let transaction =
-            VersionedTransaction::try_new(VersionedMessage::V0(msg), &[fee_payer_signer.as_ref()])?;
-        let signature =
-            crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
-                .map_err(|e| eyre::eyre!("Failed to send parent vote transaction: {}", e))?;
-
-        output::Output::header("Parent Multisig Vote Transaction Created & Sent:");
-        output::Output::field("Signature:", &signature);
-
-        // Offer to approve the parent proposal immediately (casts one Approve vote)
-        if Confirm::new("Approve this parent proposal now?")
-            .with_default(true)
-            .prompt()
-            .unwrap_or(false)
-        {
-            let parent_proposal_index = parent_next_index;
-            let approve_msg = create_parent_approve_proposal_message(
-                &program_id,
-                &parent_multisig,
-                &fee_payer_signer.pubkey(),
-                &fee_payer_signer.pubkey(),
-                parent_proposal_index,
-                blockhash,
-            )?;
-            let approve_tx = VersionedTransaction::try_new(
-                VersionedMessage::V0(approve_msg),
-                &[fee_payer_signer.as_ref()],
-            )?;
-            let approve_sig =
-                crate::provision::send_and_confirm_transaction(&approve_tx, &rpc_client)
-                    .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
-            output::Output::field("Parent proposal approved (sig):", &approve_sig);
-
-            // If approvals meet threshold, offer to execute the parent proposal now
-            let async_client =
-                AsyncRpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
-            let (approved, threshold, _status) = get_proposal_status_and_threshold(
-                &program_id,
-                &parent_multisig,
-                parent_proposal_index,
-                &async_client,
-            )
-            .await?;
-            let is_fee_payer_member = parent_ms
-                .members
-                .iter()
-                .any(|m| m.key == fee_payer_signer.pubkey());
-            // Ensure executor has Execute permission on parent multisig
-            let has_execute_permission = parent_ms
-                .members
-                .iter()
-                .find(|m| m.key == fee_payer_signer.pubkey())
-                .map(|m| (m.permissions.mask & (1 << 2)) != 0)
-                .unwrap_or(false);
-
-            if approved as u16 >= threshold && is_fee_payer_member && has_execute_permission {
-                if Confirm::new("Execute this parent proposal now?")
-                    .with_default(true)
-                    .prompt()
-                    .unwrap_or(false)
-                {
-                    // Refresh blockhash before building execute tx
-                    let fresh_blockhash = async_client.get_latest_blockhash().await?;
-                    let exec_msg = create_execute_transaction_message(
-                        &program_id,
-                        &parent_multisig,
-                        &fee_payer_signer.pubkey(),
-                        &fee_payer_signer.pubkey(),
-                        parent_proposal_index,
-                        &async_client,
-                        fresh_blockhash,
-                    )
-                    .await?;
-                    let exec_tx = VersionedTransaction::try_new(
-                        VersionedMessage::V0(exec_msg),
-                        &[fee_payer_signer.as_ref()],
-                    )?;
-                    let exec_sig =
-                        crate::provision::send_and_confirm_transaction(&exec_tx, &rpc_client)
-                            .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
-                    output::Output::field("Parent proposal executed (sig):", &exec_sig);
-                }
-            } else if !is_fee_payer_member {
-                output::Output::hint("Fee payer is not a member of the parent multisig; cannot auto-execute. Use a parent member as the executor.");
-            } else if !has_execute_permission {
-                output::Output::hint("Executor does not have Execute permission on the parent multisig; use a member with Execute to run execution.");
-            } else {
-                output::Output::hint(&format!(
-                    "Parent approvals {}/{} — waiting for more confirmations before execution.",
-                    approved, threshold
-                ));
-            }
-        }
-        return Ok(());
+        )
+        .await;
     }
 
     let transaction_message = create_common_activation_transaction_message(
@@ -379,8 +487,6 @@ pub async fn execute_common_feature_gate_proposal(
     .map_err(|e| eyre::eyre!("Failed to load fee payer: {}", e))?;
 
     let rpc_url = choose_network_from_config(config)?;
-    // Non-blocking client for data fetches, blocking for simulate/send
-    let async_client = AsyncRpcClient::new(rpc_url.clone());
     let rpc_client = create_rpc_client(&rpc_url);
 
     // Readiness check: ensure approvals >= threshold on child proposal index 1
@@ -388,15 +494,71 @@ pub async fn execute_common_feature_gate_proposal(
         &program_id,
         &feature_gate_multisig_address,
         activation_or_revocation,
-        &async_client,
-    )
-    .await?;
+        &rpc_client,
+    )?;
     if (approved as u16) < threshold {
         output::Output::hint(&format!(
             "Proposal not ready to execute yet: approvals {}/{}",
             approved, threshold
         ));
         return Err(eyre::eyre!("Insufficient approvals to execute"));
+    }
+
+    let is_parent_multisig = rpc_client
+        .get_account(&voting_key)
+        .ok()
+        .and_then(|acc| {
+            if acc.data.len() >= 8 {
+                let slice = &acc.data[8..];
+                SquadsMultisig::deserialize(&mut &slice[..]).ok()
+            } else {
+                None
+            }
+        })
+        .is_some();
+
+    if is_parent_multisig {
+        // Fetch the child transaction to get its account metas for execution
+        use crate::squads::{get_transaction_pda, VaultTransaction};
+        let (child_transaction_pda, _) = get_transaction_pda(
+            &feature_gate_multisig_address,
+            activation_or_revocation,
+            Some(&program_id),
+        );
+        let child_transaction_account_data = rpc_client
+            .get_account_data(&child_transaction_pda)
+            .map_err(|e| eyre::eyre!("Failed to fetch child transaction account: {}", e))?;
+        let child_transaction_contents =
+            VaultTransaction::try_from_slice(&child_transaction_account_data[8..])
+                .map_err(|e| eyre::eyre!("Failed to deserialize child transaction: {}", e))?;
+        let child_transaction_message = child_transaction_contents.message;
+
+        // Build execution account metas from the child transaction
+        let mut child_execution_account_metas = Vec::new();
+        for (i, account_key) in child_transaction_message.account_keys.iter().enumerate() {
+            let is_writable = child_transaction_message.is_static_writable_index(i);
+            if is_writable {
+                child_execution_account_metas
+                    .push(solana_instruction::AccountMeta::new(*account_key, false));
+            } else {
+                child_execution_account_metas.push(solana_instruction::AccountMeta::new_readonly(
+                    *account_key,
+                    false,
+                ));
+            }
+        }
+
+        return handle_parent_multisig_flow(
+            &program_id,
+            voting_key,
+            feature_gate_multisig_address,
+            activation_or_revocation,
+            &fee_payer_signer,
+            &rpc_url,
+            ParentMultisigOperation::Execute,
+            Some(child_execution_account_metas),
+        )
+        .await;
     }
 
     // Permission check: voting_key must be a member with Execute permission on the child multisig
@@ -422,17 +584,16 @@ pub async fn execute_common_feature_gate_proposal(
     }
 
     // Fresh blockhash and build execute message for proposal index 1
-    let blockhash = async_client.get_latest_blockhash().await?;
+    let blockhash = rpc_client.get_latest_blockhash()?;
     let exec_msg = create_execute_transaction_message(
         &program_id,
         &feature_gate_multisig_address,
         &voting_key,
         &fee_payer_signer.pubkey(),
         activation_or_revocation,
-        &async_client,
+        &rpc_client,
         blockhash,
-    )
-    .await?;
+    )?;
 
     let transaction = VersionedTransaction::try_new(
         VersionedMessage::V0(exec_msg),

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -11,8 +11,7 @@ use crate::squads::{get_vault_pda, Multisig as SquadsMultisig};
 use crate::{
     output,
     provision::{
-        create_approve_activation_revocation_transaction_message,
-        create_approve_activation_transaction_message, create_execute_transaction_message,
+        create_common_activation_transaction_message, create_execute_transaction_message,
         create_parent_approve_proposal_message, create_rpc_client,
         create_transaction_and_proposal_message, get_proposal_status_and_threshold,
     },
@@ -30,6 +29,43 @@ pub async fn approve_feature_gate_activation_proposal(
     voting_key: Pubkey,
     fee_payer_path: String,
     program_id: Option<Pubkey>,
+) -> Result<()> {
+    approve_common_feature_gate_proposal(
+        config,
+        feature_gate_multisig_address,
+        voting_key,
+        fee_payer_path,
+        program_id,
+        1, // activation
+    )
+    .await
+}
+
+pub async fn approve_feature_gate_activation_revocation_proposal(
+    config: &Config,
+    feature_gate_multisig_address: Pubkey,
+    voting_key: Pubkey,
+    fee_payer_path: String,
+    program_id: Option<Pubkey>,
+) -> Result<()> {
+    approve_common_feature_gate_proposal(
+        config,
+        feature_gate_multisig_address,
+        voting_key,
+        fee_payer_path,
+        program_id,
+        1, // activation
+    )
+    .await
+}
+
+pub async fn approve_common_feature_gate_proposal(
+    config: &Config,
+    feature_gate_multisig_address: Pubkey,
+    voting_key: Pubkey,
+    fee_payer_path: String,
+    program_id: Option<Pubkey>,
+    activation_or_revocation: u64,
 ) -> Result<()> {
     let program_id = program_id
         .unwrap_or_else(|| Pubkey::from_str_const("SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"));
@@ -104,7 +140,7 @@ pub async fn approve_feature_gate_activation_proposal(
 
         let tx_message = create_child_vote_approve_transaction_message(
             feature_gate_multisig_address,
-            1,
+            activation_or_revocation,
             parent_vault_member,
         );
 
@@ -222,12 +258,13 @@ pub async fn approve_feature_gate_activation_proposal(
         return Ok(());
     }
 
-    let transaction_message = create_approve_activation_transaction_message(
+    let transaction_message = create_common_activation_transaction_message(
         &program_id,
         &feature_gate_multisig_address,
         &voting_key,
         &fee_payer_keypair.as_ref().unwrap().pubkey(),
         blockhash,
+        activation_or_revocation,
     )
     .map_err(|e| {
         eyre::eyre!(
@@ -269,253 +306,49 @@ pub async fn approve_feature_gate_activation_proposal(
     Ok(())
 }
 
-pub async fn approve_feature_gate_activation_revocation_proposal(
-    config: &Config,
-    feature_gate_multisig_address: Pubkey,
-    voting_key: Pubkey,
-    fee_payer_path: String,
-    program_id: Option<Pubkey>,
-) -> Result<()> {
-    let program_id = program_id
-        .unwrap_or_else(|| Pubkey::from_str_const("SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"));
-
-    let fee_payer_keypair = load_fee_payer_keypair(config, Some(fee_payer_path))?;
-    let rpc_url = choose_network_from_config(config)?;
-    let rpc_client = create_rpc_client(&rpc_url);
-    let blockhash = rpc_client
-        .get_latest_blockhash()
-        .map_err(|e| eyre::eyre!("Failed to get recent blockhash: {}", e))?;
-
-    // Detect if voting_key is a Squads multisig (parent) for revocation path
-    let is_parent_multisig = rpc_client
-        .get_account(&voting_key)
-        .ok()
-        .and_then(|acc| {
-            if acc.data.len() >= 8 {
-                let slice = &acc.data[8..];
-                SquadsMultisig::deserialize(&mut &slice[..]).ok()
-            } else {
-                None
-            }
-        })
-        .is_some();
-
-    if is_parent_multisig {
-        let parent_multisig = voting_key;
-        let parent_acc = rpc_client
-            .get_account(&parent_multisig)
-            .map_err(|e| eyre::eyre!("Failed to fetch parent multisig account: {}", e))?;
-        let parent_ms: SquadsMultisig =
-            BorshDeserialize::deserialize(&mut &parent_acc.data[8..])
-                .map_err(|e| eyre::eyre!("Failed to deserialize parent multisig: {}", e))?;
-        let parent_next_index = parent_ms.transaction_index + 1;
-
-        let parent_vault_member = get_vault_pda(&parent_multisig, 0, None).0;
-
-        // Validate child membership for parent vault PDA with Vote permission
-        let child_acc = rpc_client
-            .get_account(&feature_gate_multisig_address)
-            .map_err(|e| eyre::eyre!("Failed to fetch child multisig: {}", e))?;
-        let child_ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &child_acc.data[8..])
-            .map_err(|e| eyre::eyre!("Failed to deserialize child multisig: {}", e))?;
-        let parent_vault_is_member_with_vote = child_ms
-            .members
-            .iter()
-            .any(|m| m.key == parent_vault_member && (m.permissions.mask & (1 << 1)) != 0);
-
-        if !parent_vault_is_member_with_vote {
-            let parent_multisig_is_member =
-                child_ms.members.iter().any(|m| m.key == parent_multisig);
-            if parent_multisig_is_member {
-                output::Output::error("Child multisig has the parent multisig address as a member, but not the parent vault PDA. The parent program cannot sign as the multisig address during CPI.");
-                output::Output::hint(&format!(
-                    "Please add the parent vault PDA as a member with Vote permission on the child: {}",
-                    parent_vault_member
-                ));
-            } else {
-                output::Output::error("Child multisig is missing the parent vault PDA as a member with Vote permission.");
-                output::Output::hint(&format!(
-                    "Add this key as a member with Vote: {}",
-                    parent_vault_member
-                ));
-            }
-            return Err(eyre::eyre!(
-                "Child multisig missing required member for programmatic approval"
-            ));
-        }
-
-        let tx_message = create_child_vote_approve_transaction_message(
-            feature_gate_multisig_address,
-            2,
-            parent_vault_member,
-        );
-
-        let (msg, tx_pda, prop_pda) = create_transaction_and_proposal_message(
-            None,
-            &fee_payer_keypair.as_ref().unwrap().pubkey(),
-            &fee_payer_keypair.as_ref().unwrap().pubkey(),
-            &parent_multisig,
-            parent_next_index,
-            0,
-            tx_message,
-            Some(5000),
-            Some(crate::constants::DEFAULT_COMPUTE_UNITS),
-            blockhash,
-        )?;
-        output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
-        output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
-
-        let fee_payer_signer = fee_payer_keypair.as_ref().unwrap();
-        let transaction = VersionedTransaction::try_new(
-            VersionedMessage::V0(msg),
-            &[fee_payer_signer as &dyn Signer],
-        )?;
-        let signature =
-            crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
-                .map_err(|e| eyre::eyre!("Failed to send parent vote transaction: {}", e))?;
-
-        output::Output::header("Parent Multisig Vote Transaction Created & Sent:");
-        output::Output::field("Signature:", &signature);
-
-        if Confirm::new("Approve this parent proposal now?")
-            .with_default(true)
-            .prompt()
-            .unwrap_or(false)
-        {
-            let parent_proposal_index = parent_next_index;
-            let approve_msg = create_parent_approve_proposal_message(
-                &program_id,
-                &parent_multisig,
-                &fee_payer_keypair.as_ref().unwrap().pubkey(),
-                &fee_payer_keypair.as_ref().unwrap().pubkey(),
-                parent_proposal_index,
-                blockhash,
-            )?;
-            let approve_tx = VersionedTransaction::try_new(
-                VersionedMessage::V0(approve_msg),
-                &[fee_payer_signer as &dyn Signer],
-            )?;
-            let approve_sig =
-                crate::provision::send_and_confirm_transaction(&approve_tx, &rpc_client)
-                    .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
-            output::Output::field("Parent proposal approved (sig):", &approve_sig);
-
-            // If approvals meet threshold, offer to execute the parent proposal now
-            let async_client =
-                AsyncRpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
-            let (approved, threshold, _status) = get_proposal_status_and_threshold(
-                &program_id,
-                &parent_multisig,
-                parent_proposal_index,
-                &async_client,
-            )
-            .await?;
-            let is_fee_payer_member = parent_ms
-                .members
-                .iter()
-                .any(|m| m.key == fee_payer_signer.pubkey());
-            let has_execute_permission = parent_ms
-                .members
-                .iter()
-                .find(|m| m.key == fee_payer_signer.pubkey())
-                .map(|m| (m.permissions.mask & (1 << 2)) != 0)
-                .unwrap_or(false);
-
-            if approved as u16 >= threshold && is_fee_payer_member && has_execute_permission {
-                if Confirm::new("Execute this parent proposal now?")
-                    .with_default(true)
-                    .prompt()
-                    .unwrap_or(false)
-                {
-                    // Briefly poll until status reflects approval on-chain
-                    let fresh_blockhash = async_client.get_latest_blockhash().await?;
-                    let exec_msg = create_execute_transaction_message(
-                        &program_id,
-                        &parent_multisig,
-                        &fee_payer_signer.pubkey(),
-                        &fee_payer_signer.pubkey(),
-                        parent_proposal_index,
-                        &async_client,
-                        fresh_blockhash,
-                    )
-                    .await?;
-                    let exec_tx = VersionedTransaction::try_new(
-                        VersionedMessage::V0(exec_msg),
-                        &[fee_payer_signer as &dyn Signer],
-                    )?;
-                    let exec_sig =
-                        crate::provision::send_and_confirm_transaction(&exec_tx, &rpc_client)
-                            .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
-                    output::Output::field("Parent proposal executed (sig):", &exec_sig);
-                }
-            } else if !is_fee_payer_member {
-                output::Output::hint("Fee payer is not a member of the parent multisig; cannot auto-execute. Use a parent member as the executor.");
-            } else if !has_execute_permission {
-                output::Output::hint("Executor does not have Execute permission on the parent multisig; use a member with Execute to run execution.");
-            } else {
-                output::Output::hint(&format!(
-                    "Parent approvals {}/{} — waiting for more confirmations before execution.",
-                    approved, threshold
-                ));
-            }
-        }
-        return Ok(());
-    }
-
-    let transaction_message = create_approve_activation_revocation_transaction_message(
-        &program_id,
-        &feature_gate_multisig_address,
-        &voting_key,
-        &fee_payer_keypair.as_ref().unwrap().pubkey(),
-        blockhash,
-    )
-    .map_err(|e| {
-        eyre::eyre!(
-            "Failed to create approve activation transaction message: {}",
-            e
-        )
-    })?;
-
-    let transaction = VersionedTransaction::try_new(
-        VersionedMessage::V0(transaction_message),
-        &[&fee_payer_keypair.unwrap()],
-    )?;
-
-    let serialized_transaction = bincode::serialize(&transaction)?;
-
-    let transaction_encoded_bs58 = bs58::encode(&serialized_transaction).into_string();
-    let transaction_encoded_base64 = B64.encode(&serialized_transaction);
-
-    output::Output::header("Encoded Transactions:");
-    output::Output::separator();
-    output::Output::field("Base58:", &transaction_encoded_bs58);
-    output::Output::separator();
-    output::Output::field("Base64:", &transaction_encoded_base64);
-
-    // Confirm before sending on-chain (EOA approval path)
-    let should_send = Confirm::new("Send this approve transaction now?")
-        .with_default(true)
-        .prompt()
-        .unwrap_or(false);
-    if !should_send {
-        output::Output::separator();
-        output::Output::hint("Skipped sending. You can submit the above encoded transaction manually or rerun to send.");
-        return Ok(());
-    }
-
-    let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
-        .map_err(|e| eyre::eyre!("Failed to send transaction and proposal: {}", e))?;
-    output::Output::separator();
-    output::Output::field("Transaction sent successfully:", &signature);
-    Ok(())
-}
-
 pub async fn execute_feature_gate_activation_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
     fee_payer_path: String,
     program_id: Option<Pubkey>,
+) -> Result<()> {
+    execute_common_feature_gate_proposal(
+        config,
+        feature_gate_multisig_address,
+        voting_key,
+        fee_payer_path,
+        program_id,
+        1,
+    )
+    .await
+}
+
+pub async fn execute_feature_gate_revocation_proposal(
+    config: &Config,
+    feature_gate_multisig_address: Pubkey,
+    voting_key: Pubkey,
+    fee_payer_path: String,
+    program_id: Option<Pubkey>,
+) -> Result<()> {
+    execute_common_feature_gate_proposal(
+        config,
+        feature_gate_multisig_address,
+        voting_key,
+        fee_payer_path,
+        program_id,
+        2,
+    )
+    .await
+}
+
+pub async fn execute_common_feature_gate_proposal(
+    config: &Config,
+    feature_gate_multisig_address: Pubkey,
+    voting_key: Pubkey,
+    fee_payer_path: String,
+    program_id: Option<Pubkey>,
+    activation_or_revocation: u64,
 ) -> Result<()> {
     let program_id = program_id
         .unwrap_or_else(|| Pubkey::from_str_const("SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"));
@@ -530,7 +363,7 @@ pub async fn execute_feature_gate_activation_proposal(
     let (approved, threshold, _status) = get_proposal_status_and_threshold(
         &program_id,
         &feature_gate_multisig_address,
-        1,
+        activation_or_revocation,
         &async_client,
     )
     .await?;
@@ -571,7 +404,7 @@ pub async fn execute_feature_gate_activation_proposal(
         &feature_gate_multisig_address,
         &voting_key,
         &fee_payer_keypair.as_ref().unwrap().pubkey(),
-        1,
+        activation_or_revocation,
         &async_client,
         blockhash,
     )

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -146,6 +146,33 @@ pub async fn approve_common_feature_gate_proposal(
             ));
         }
 
+        // Display information about the parent multisig transaction that will be created
+        output::Output::header("Parent Multisig Transaction Details:");
+        output::Output::field("Parent Multisig:", &parent_multisig.to_string());
+        output::Output::field(
+            "Child Multisig:",
+            &feature_gate_multisig_address.to_string(),
+        );
+        output::Output::field("Transaction Index:", &parent_next_index.to_string());
+        output::Output::field(
+            "Action:",
+            if activation_or_revocation == 1 {
+                "Approve Feature Gate Activation"
+            } else {
+                "Approve Feature Gate Revocation"
+            },
+        );
+
+        // Ask for confirmation before creating the parent multisig proposal
+        if !Confirm::new("Create parent multisig proposal for this transaction?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+        {
+            output::Output::info("Parent multisig proposal creation cancelled.");
+            return Ok(());
+        }
+
         let tx_message = create_child_vote_approve_transaction_message(
             feature_gate_multisig_address,
             activation_or_revocation,

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -6,7 +6,6 @@ use solana_message::VersionedMessage;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use solana_transaction::versioned::VersionedTransaction;
-use tokio::time::{sleep, Duration};
 
 use crate::squads::{get_vault_pda, Multisig as SquadsMultisig};
 use crate::{
@@ -188,23 +187,6 @@ pub async fn approve_feature_gate_activation_proposal(
                     .prompt()
                     .unwrap_or(false)
                 {
-                    // Briefly poll until status reflects approval on-chain to avoid races
-                    let mut tries = 0;
-                    while tries < 10 {
-                        let (appr, _th, _st) = get_proposal_status_and_threshold(
-                            &program_id,
-                            &parent_multisig,
-                            parent_proposal_index,
-                            &async_client,
-                        )
-                        .await?;
-                        if appr as u16 >= threshold {
-                            break;
-                        }
-                        sleep(Duration::from_millis(400)).await;
-                        tries += 1;
-                    }
-
                     // Refresh blockhash before building execute tx
                     let fresh_blockhash = async_client.get_latest_blockhash().await?;
                     let exec_msg = create_execute_transaction_message(
@@ -436,22 +418,6 @@ pub async fn approve_feature_gate_activation_revocation_proposal(
                     .unwrap_or(false)
                 {
                     // Briefly poll until status reflects approval on-chain
-                    let mut tries = 0;
-                    while tries < 10 {
-                        let (appr, _th, _st) = get_proposal_status_and_threshold(
-                            &program_id,
-                            &parent_multisig,
-                            parent_proposal_index,
-                            &async_client,
-                        )
-                        .await?;
-                        if appr as u16 >= threshold {
-                            break;
-                        }
-                        sleep(Duration::from_millis(400)).await;
-                        tries += 1;
-                    }
-
                     let fresh_blockhash = async_client.get_latest_blockhash().await?;
                     let exec_msg = create_execute_transaction_message(
                         &program_id,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,7 +16,7 @@ pub const BASE_RETRY_DELAY_MS: u64 = 500;
 pub const CONFIRMATION_TIMEOUT_MS: u64 = 30_000; // 30 seconds
 pub const CONFIRMATION_POLL_INTERVAL_MS: u64 = 1000; // 1 second
 
-// Account data retry constants  
+// Account data retry constants
 pub const MAX_ACCOUNT_RETRIES: usize = 3;
 pub const BASE_ACCOUNT_RETRY_DELAY_MS: u64 = 500;
 

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -721,53 +721,20 @@ pub fn create_transaction_and_proposal_message(
     Ok((message, transaction_pda, proposal_pda))
 }
 
-pub fn create_approve_activation_transaction_message(
+pub fn create_common_activation_transaction_message(
     program_id: &Pubkey,
     feature_gate_multisig_address: &Pubkey,
     member_pubkey: &Pubkey,
     fee_payer_pubkey: &Pubkey,
     recent_blockhash: Hash,
+    proposal_index: u64,
 ) -> eyre::Result<Message> {
     // Activation proposal index is 1 (proposal 0 is reserved for the initial create)
-    let (proposal_pda, _proposal_bump) =
-        get_proposal_pda(feature_gate_multisig_address, 1, Some(program_id));
-
-    let account_keys = MultisigVoteOnProposalAccounts {
-        multisig: *feature_gate_multisig_address,
-        member: *member_pubkey,
-        proposal: proposal_pda,
-    };
-    let instruction_args = MultisigVoteOnProposalArgs { memo: None };
-    let instruction_data = MultisigApproveProposalData {
-        args: instruction_args,
-    };
-
-    let approve_instruction = Instruction::new_with_bytes(
-        *program_id,
-        &instruction_data.data(),
-        account_keys.to_account_metas(),
+    let (proposal_pda, _proposal_bump) = get_proposal_pda(
+        feature_gate_multisig_address,
+        proposal_index,
+        Some(program_id),
     );
-
-    let message = Message::try_compile(
-        fee_payer_pubkey,
-        &[approve_instruction],
-        &[],
-        recent_blockhash,
-    )?;
-
-    Ok(message)
-}
-
-pub fn create_approve_activation_revocation_transaction_message(
-    program_id: &Pubkey,
-    feature_gate_multisig_address: &Pubkey,
-    member_pubkey: &Pubkey,
-    fee_payer_pubkey: &Pubkey,
-    recent_blockhash: Hash,
-) -> eyre::Result<Message> {
-    // Revocation proposal index is 2
-    let (proposal_pda, _proposal_bump) =
-        get_proposal_pda(feature_gate_multisig_address, 2, Some(program_id));
 
     let account_keys = MultisigVoteOnProposalAccounts {
         multisig: *feature_gate_multisig_address,

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -4,10 +4,11 @@ use crate::squads::{
     Member, MultisigApproveProposalData, MultisigCreateArgsV2, MultisigCreateProposalAccounts,
     MultisigCreateProposalArgs, MultisigCreateProposalData, MultisigCreateTransaction,
     MultisigCreateV2Accounts, MultisigCreateV2Data, MultisigExecuteTransactionAccounts,
-    MultisigVoteOnProposalAccounts, MultisigVoteOnProposalArgs, Permissions, ProgramConfig,
-    TransactionMessage, VaultTransaction, VaultTransactionCreateArgs,
-    VaultTransactionCreateArgsData, EXECUTE_TRANSACTION_DISCRIMINATOR,
+    MultisigExecuteTransactionArgs, MultisigVoteOnProposalAccounts, MultisigVoteOnProposalArgs,
+    Permissions, ProgramConfig, SmallVec, TransactionMessage, VaultTransactionCreateArgs,
+    VaultTransactionCreateArgsData, EXECUTE_TRANSACTION_DISCRIMINATOR, SQUADS_MULTISIG_PROGRAM_ID,
 };
+
 use crate::utils::decode_permissions;
 use borsh::BorshDeserialize;
 use colored::Colorize;
@@ -15,7 +16,6 @@ use dialoguer::Confirm;
 use eyre::eyre;
 use indicatif::ProgressBar;
 use solana_client::client_error::ClientErrorKind;
-use solana_client::nonblocking;
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_client::rpc_request::{RpcError, RpcResponseErrorData};
@@ -801,95 +801,163 @@ pub fn create_parent_approve_proposal_message(
 }
 
 /// Fetch proposal approvals count, parent threshold, and proposal status for a given proposal index.
-pub async fn get_proposal_status_and_threshold(
+pub fn get_proposal_status_and_threshold(
     program_id: &Pubkey,
     multisig_address: &Pubkey,
     proposal_index: u64,
-    rpc_client: &nonblocking::rpc_client::RpcClient,
+    rpc_client: &RpcClient,
 ) -> eyre::Result<(usize, u16, crate::squads::ProposalStatus)> {
     use crate::squads::{get_proposal_pda, Multisig as SquadsMultisig, Proposal};
-    use borsh::BorshDeserialize;
 
     // Multisig threshold
-    let ms_acc = rpc_client.get_account(multisig_address).await?;
+    let ms_acc = rpc_client.get_account(multisig_address)?;
     let ms: SquadsMultisig = BorshDeserialize::deserialize(&mut &ms_acc.data[8..])
         .map_err(|e| eyre::eyre!("Failed to deserialize multisig: {}", e))?;
 
     // Proposal approved count and status
     let (proposal_pda, _) = get_proposal_pda(multisig_address, proposal_index, Some(program_id));
-    let prop_acc = rpc_client.get_account(&proposal_pda).await?;
+    let prop_acc = rpc_client.get_account(&proposal_pda)?;
     let prop: Proposal = BorshDeserialize::deserialize(&mut &prop_acc.data[8..])
         .map_err(|e| eyre::eyre!("Failed to deserialize proposal: {}", e))?;
 
     Ok((prop.approved.len(), ms.threshold, prop.status))
 }
-pub async fn create_execute_activation_transaction_message(
-    program_id: &Pubkey,
-    feature_gate_multisig_address: &Pubkey,
-    member_pubkey: &Pubkey,
-    fee_payer_pubkey: &Pubkey,
-    rpc_client: &nonblocking::rpc_client::RpcClient,
-    recent_blockhash: Hash,
-) -> eyre::Result<Message> {
-    // Activation proposal/transaction indexes are 1
-    let (proposal_pda, _proposal_bump) =
-        get_proposal_pda(feature_gate_multisig_address, 1, Some(program_id));
-    let (transaction_pda, _transaction_bump) =
-        get_transaction_pda(feature_gate_multisig_address, 1, Some(program_id));
-    let _vault_pda = get_vault_pda(feature_gate_multisig_address, 0, Some(program_id));
 
-    let transaction_account_data = rpc_client.get_account_data(&transaction_pda).await?;
-    let transaction_contents =
-        VaultTransaction::try_from_slice(&transaction_account_data[8..]).unwrap();
-    let transaction_message = transaction_contents.message;
+/// Build a TransactionMessage for a parent multisig to execute a child's proposal.
+/// This creates a single instruction that calls Squads `ExecuteTransaction` on the child multisig,
+/// with `member_pubkey` set to the parent vault PDA. The resulting TransactionMessage can
+/// be embedded into a parent multisig transaction using `create_transaction_and_proposal_message`.
+pub fn create_child_execute_transaction_message(
+    child_multisig: Pubkey,
+    child_tx_index: u64,
+    parent_member_pubkey: Pubkey,
+    child_transaction_accounts: Vec<solana_instruction::AccountMeta>,
+) -> TransactionMessage {
+    // Derive child's proposal and transaction PDAs
+    let (proposal_pda, _) = get_proposal_pda(
+        &child_multisig,
+        child_tx_index,
+        Some(&SQUADS_MULTISIG_PROGRAM_ID),
+    );
+    let (transaction_pda, _) = get_transaction_pda(
+        &child_multisig,
+        child_tx_index,
+        Some(&SQUADS_MULTISIG_PROGRAM_ID),
+    );
 
-    let mut execution_account_metas = Vec::new();
-    // Build account metas from transaction_message
-    for (i, account_key) in transaction_message.account_keys.iter().enumerate() {
-        // Inner message signer flags should NOT require outer transaction signatures.
-        // The program will handle signing (ephemeral/program signers) during execution.
-        let is_writable = transaction_message.is_static_writable_index(i);
-        if is_writable {
-            execution_account_metas.push(AccountMeta::new(*account_key, false));
+    // Construct the execute instruction for the child multisig
+    let accounts = MultisigExecuteTransactionAccounts {
+        multisig: child_multisig,
+        proposal: proposal_pda,
+        transaction: transaction_pda,
+        member: parent_member_pubkey,
+    };
+
+    let args = MultisigExecuteTransactionArgs { memo: None };
+    let mut instruction_data = Vec::new();
+    instruction_data.extend_from_slice(EXECUTE_TRANSACTION_DISCRIMINATOR);
+    instruction_data.extend_from_slice(&borsh::to_vec(&args).unwrap());
+
+    let header_set: std::collections::HashSet<Pubkey> = [
+        child_multisig,
+        proposal_pda,
+        transaction_pda,
+        parent_member_pubkey,
+    ]
+    .into_iter()
+    .collect();
+
+    let filtered_dynamic_accounts: Vec<solana_instruction::AccountMeta> =
+        child_transaction_accounts
+            .into_iter()
+            .filter(|m| !header_set.contains(&m.pubkey))
+            .collect();
+
+    // Build metas in correct header+dynamic order for Squads message grouping
+    let all_metas = accounts.to_account_metas(filtered_dynamic_accounts);
+
+    // Group account_keys to match Squads TransactionMessage layout:
+    // [signers | writable non-signers | readonly non-signers]
+    let mut signer_keys: Vec<Pubkey> = vec![parent_member_pubkey];
+    let mut writable_non_signers: Vec<Pubkey> = Vec::new();
+    let mut readonly_non_signers: Vec<Pubkey> = Vec::new();
+
+    for m in &all_metas {
+        if m.is_signer {
+            if m.pubkey != parent_member_pubkey {
+                signer_keys.push(m.pubkey);
+            }
+        } else if m.is_writable {
+            writable_non_signers.push(m.pubkey);
         } else {
-            execution_account_metas.push(AccountMeta::new_readonly(*account_key, false));
+            readonly_non_signers.push(m.pubkey);
         }
     }
 
-    let account_keys = MultisigExecuteTransactionAccounts {
-        multisig: *feature_gate_multisig_address,
-        proposal: proposal_pda,
-        transaction: transaction_pda,
-        member: *member_pubkey,
+    // Ensure header accounts are present in the correct groups
+    // proposal must be writable, multisig/transaction readonly
+    if !writable_non_signers.contains(&proposal_pda) {
+        writable_non_signers.insert(0, proposal_pda);
+    }
+    if !readonly_non_signers.contains(&child_multisig) {
+        readonly_non_signers.insert(0, child_multisig);
+    }
+    if !readonly_non_signers.contains(&transaction_pda) {
+        readonly_non_signers.insert(1, transaction_pda);
+    }
+
+    // Construct final account_keys list in grouped order
+    let mut account_keys: Vec<Pubkey> = Vec::new();
+    account_keys.extend(signer_keys.iter().copied());
+    account_keys.extend(writable_non_signers.iter().copied());
+    // Program id goes in readonly non-signers as well
+    if !readonly_non_signers.contains(&SQUADS_MULTISIG_PROGRAM_ID) {
+        readonly_non_signers.push(SQUADS_MULTISIG_PROGRAM_ID);
+    }
+    account_keys.extend(readonly_non_signers.iter().copied());
+
+    let program_id_index = account_keys
+        .iter()
+        .position(|k| *k == SQUADS_MULTISIG_PROGRAM_ID)
+        .unwrap() as u8;
+
+    let account_indexes: Vec<u8> = all_metas
+        .iter()
+        .map(|meta| {
+            account_keys
+                .iter()
+                .position(|k| *k == meta.pubkey)
+                .expect("meta key present in account_keys") as u8
+        })
+        .collect();
+
+    let compiled = crate::squads::CompiledInstruction {
+        program_id_index,
+        account_indexes: SmallVec::from(account_indexes),
+        data: SmallVec::from(instruction_data.clone()),
     };
 
-    // Include dynamic metas from the inner transaction message
-    let account_metas = account_keys.to_account_metas(execution_account_metas);
+    // Count writable non-signers from the instruction metas directly
+    let num_writable_non_signers = writable_non_signers.len() as u8;
 
-    let execute_instruction = Instruction::new_with_bytes(
-        *program_id,
-        &EXECUTE_TRANSACTION_DISCRIMINATOR,
-        account_metas,
-    );
-
-    let message = Message::try_compile(
-        fee_payer_pubkey,
-        &[execute_instruction],
-        &[],
-        recent_blockhash,
-    )?;
-
-    Ok(message)
+    TransactionMessage {
+        num_signers: signer_keys.len() as u8,
+        num_writable_signers: 0, // execute expects member signer to be readonly
+        num_writable_non_signers,
+        account_keys: SmallVec::from(account_keys),
+        instructions: SmallVec::from(vec![compiled]),
+        address_table_lookups: SmallVec::from(vec![]),
+    }
 }
 
 /// Create an execute message for any Squads multisig proposal at `proposal_index`.
-pub async fn create_execute_transaction_message(
+pub fn create_execute_transaction_message(
     program_id: &Pubkey,
     multisig_address: &Pubkey,
     member_pubkey: &Pubkey,
     fee_payer_pubkey: &Pubkey,
     proposal_index: u64,
-    rpc_client: &nonblocking::rpc_client::RpcClient,
+    rpc_client: &RpcClient,
     recent_blockhash: Hash,
 ) -> eyre::Result<Message> {
     use crate::squads::{
@@ -902,7 +970,7 @@ pub async fn create_execute_transaction_message(
         get_transaction_pda(multisig_address, proposal_index, Some(program_id));
     let _vault_pda = get_vault_pda(multisig_address, 0, Some(program_id));
 
-    let transaction_account_data = rpc_client.get_account_data(&transaction_pda).await?;
+    let transaction_account_data = rpc_client.get_account_data(&transaction_pda)?;
     let transaction_contents =
         VaultTransaction::try_from_slice(&transaction_account_data[8..]).unwrap();
     let transaction_message = transaction_contents.message;
@@ -971,7 +1039,7 @@ pub fn parse_members(member_strings: Vec<String>) -> Result<Vec<Member>, String>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::squads::{CompiledInstruction, SmallVec, TransactionMessage};
+    use crate::squads::CompiledInstruction;
     use borsh::BorshDeserialize;
 
     fn create_test_transaction_message() -> TransactionMessage {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -289,10 +289,7 @@ pub fn prompt_for_pubkey(prompt: &str) -> Result<Pubkey> {
 }
 
 pub fn prompt_for_fee_payer_path(config: &Config) -> Result<String> {
-    let default_feepayer = config
-        .fee_payer_path
-        .as_deref()
-        .unwrap_or("~/.config/solana/id.json");
+    let default_feepayer = config.fee_payer_path.as_deref().unwrap_or("usb://ledger");
 
     let feepayer_path = Text::new("Enter fee payer keypair file path:")
         .with_default(default_feepayer)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -662,7 +662,7 @@ pub fn create_feature_revocation_transaction_message(feature_id: Pubkey) -> Tran
 
 pub async fn create_and_send_transaction_proposal(
     rpc_url: &str,
-    fee_payer_keypair: &Option<Keypair>,
+    fee_payer_signer: &Box<dyn Signer>,
     contributor_keypair: &Keypair,
     multisig_address: &Pubkey,
     transaction_type: &str,
@@ -686,10 +686,7 @@ pub async fn create_and_send_transaction_proposal(
         .get_latest_blockhash()
         .map_err(|e| eyre::eyre!("Failed to get recent blockhash: {}", e))?;
 
-    let fee_payer_pubkey = fee_payer_keypair
-        .as_ref()
-        .map(|kp| kp.pubkey())
-        .unwrap_or_else(|| contributor_keypair.pubkey());
+    let fee_payer_pubkey = fee_payer_signer.pubkey();
 
     // Use the integrated create_transaction_and_proposal_message function from provision.rs
     let (message, _transaction_pda, _proposal_pda) =
@@ -711,7 +708,7 @@ pub async fn create_and_send_transaction_proposal(
         &[contributor_keypair]
     } else {
         &[
-            fee_payer_keypair.as_ref().unwrap() as &dyn Signer,
+            fee_payer_signer.as_ref(),
             contributor_keypair as &dyn Signer,
         ]
     };


### PR DESCRIPTION
Thanks for writting up the base code, I made some changes to closer allign with what we want the cli to do, in particular:

the key use case is where we have the following setup:

             
![Screenshot 2025-11-12 at 15 15 24](https://github.com/user-attachments/assets/85f2285a-354b-4eff-8ab0-540baeb46d5a)

Hence, we need to generate a nested parent multi-sig proposal, which basically this PR adds.

**Changes**:
1. Adding approval/revocation parent proposal generation based on the fee payer being a member of the parent multisig
      1. Due to parent multisig being 1/n, we can generate approval + execution tx straight away as well.    
2. Adds the same as above for execution, but requires slightly different logic as you need to pass in different accounts, which makes transaction setup more complex (This works, but it's the part I am not 100% sure about)
3. Added hardware key support (ledger) and made it the default option
4. When a voting account is provided, the on-chain program that it represents is parsed, and if it's a Squads multisig, we go into multisig flow; otherwise, we treat it as a non-Squads account and sign directly with it.

**Things to do**:
1. It would be very good to be able to disable keys in a rekeying situation, so adding the ability to either remove all owners or move ownership to an inaccessible account would be ideal. But that still needs to be added.
2. I have done happy path testing, but we really need to add a test suite. 

Would appreciate a review, and hopefully we could start using this soon.