### PR TITLE
Docs and tooling fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,10 @@ tokio = { version = "1.0", features = ["full"] }
 solana-program = "2.0.0"
 solana-client = "2.0.0"
 once_cell = "1.19"
+
+[lints.clippy]
+# Catch debugging/placeholder leftovers. Wider pedantic adoption is deferred
+# (~260 findings) — track separately.
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ surfpool-start:
 
 .PHONY: test-surfpool
 test-surfpool:
+	@mkdir -p artifacts
 	@echo "Starting surfpool in background..."
 	@(surfpool start --no-tui > artifacts/surfpool.log 2>&1 &)
 	@sleep 5
 	@echo "Running RPC E2E tests..."
-	@RPC_URL=http://127.0.0.1:8899 cargo test rpc_e2e_ -- --test-threads=1 --nocapture || true
-	@echo "Stopping surfpool..."
-	@pkill -f surfpool || true
+	@RPC_URL=http://127.0.0.1:8899 cargo test rpc_e2e_ -- --test-threads=1 --nocapture; \
+		status=$$?; \
+		echo "Stopping surfpool..."; \
+		pkill -KILL -f 'surfpool start' || true; \
+		exit $$status

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The CLI will display the required PDA if misconfigured. See [Parent Multisig Vot
 
 ## Configuration
 
-Stored at `~/.feature-gate-multisig-tool/config.json`:
+Stored as `config.json` in the directory where the tool is run:
 
 ```json
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ Features:
 
 For more information, run: feature-gate-multisig-tool help <COMMAND>"
 )]
-#[command(version = "0.1.0")]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,9 +67,8 @@ pub fn get_network_display(rpc_url: &str) -> &'static str {
 
 // Config management functions
 
-/// Returns the path to the local config file in the current working directory.
-/// The config file is named `feature-gate-multisig.json` and is stored in the
-/// directory where the tool is run from.
+/// Returns the path to the local config file (`config.json`) in the current
+/// working directory — the directory where the tool is run from.
 pub fn get_config_path() -> Result<PathBuf> {
     let current_dir =
         env::current_dir().map_err(|e| eyre::eyre!("Could not get current directory: {}", e))?;


### PR DESCRIPTION
- **`make test-surfpool` now reports failures.** It used to end in `|| true`, so the target passed even when tests failed. Now it captures and propagates the real exit code.
- **Version no longer hardcoded**, `--version` was stuck at `0.1.0` while Cargo.toml said `0.2.0`; now it derives from Cargo.toml.
- **Added a small `[lints.clippy]`** denying `dbg_macro`/`todo`/`unimplemented`. (Skipped full `pedantic` for now — it's ~260 findings, separate task.)
