### PR TITLE
remove async + tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,6 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction",
  "tabled",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 inquire = "0.7"
-tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs = "5.0"
@@ -38,7 +37,6 @@ solana-hash = "2.0.0"
 [dev-dependencies]
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-tokio = { version = "1.0", features = ["full"] }
 solana-program = "2.0.0"
 solana-client = "2.0.0"
 once_cell = "1.19"

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use crate::output::Output;
 use crate::utils::*;
 use eyre::Result;
 
-pub async fn config_command(config: &Config) -> Result<()> {
+pub fn config_command(config: &Config) -> Result<()> {
     let config_path = get_config_path()?;
     let config_path_str = config_path.to_string_lossy();
 

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -14,18 +14,18 @@ use solana_message::VersionedMessage;
 use solana_signer::Signer;
 use solana_transaction::versioned::VersionedTransaction;
 
-pub async fn create_command(
+pub fn create_command(
     config: &mut Config,
     threshold: Option<u16>,
     keypair_path: Option<String>,
 ) -> Result<()> {
     // Keep existing behaviour, but discard returned deployments
-    let _ = create_command_with_deployments(config, threshold, keypair_path).await?;
+    let _ = create_command_with_deployments(config, threshold, keypair_path)?;
     Ok(())
 }
 
 /// Variant of `create_command` that returns deployment details (used by E2E tests).
-pub async fn create_command_with_deployments(
+pub fn create_command_with_deployments(
     config: &mut Config,
     threshold: Option<u16>,
     keypair_path: Option<String>,
@@ -72,7 +72,7 @@ pub async fn create_command_with_deployments(
     if use_saved_networks && !saved_networks.is_empty() {
         let fee_payer_pubkey = fee_payer_signer.pubkey();
 
-        check_fee_payer_balance_on_networks(&fee_payer_pubkey, &saved_networks, 0.05).await?;
+        check_fee_payer_balance_on_networks(&fee_payer_pubkey, &saved_networks, 0.05)?;
     }
 
     let deployments = if use_saved_networks && !saved_networks.is_empty() {
@@ -83,8 +83,7 @@ pub async fn create_command_with_deployments(
             &fee_payer_signer,
             &members,
             final_threshold,
-        )
-        .await?
+        )?
     } else {
         deploy_to_manual_networks(
             config,
@@ -93,8 +92,7 @@ pub async fn create_command_with_deployments(
             &fee_payer_signer,
             &members,
             final_threshold,
-        )
-        .await?
+        )?
     };
 
     // Print summary table
@@ -124,7 +122,7 @@ pub async fn create_command_with_deployments(
     Ok(deployments)
 }
 
-async fn deploy_to_single_network(
+fn deploy_to_single_network(
     rpc_url: &str,
     create_key: &Keypair,
     setup_keypair: &Keypair,
@@ -142,7 +140,6 @@ async fn deploy_to_single_network(
         threshold,
         Some(crate::constants::DEFAULT_PRIORITY_FEE), // Priority fee
     )
-    .await
     .map_err(|e| eyre::eyre!("Failed to create multisig: {}", e))?;
 
     let vault_address = get_vault_pda(&multisig_address, 0).0;
@@ -171,7 +168,7 @@ async fn deploy_to_single_network(
         .map_err(|e| eyre::eyre!("Failed to create activation proposal: {}", e))?;
 
     // Fund the vault address (feature gate account) with rent-exempt lamports
-    create_and_send_funding_transaction(rpc_url, fee_payer_signer, &vault_address).await?;
+    create_and_send_funding_transaction(rpc_url, fee_payer_signer, &vault_address)?;
 
     Ok(DeploymentResult {
         rpc_url: rpc_url.to_string(),
@@ -181,7 +178,7 @@ async fn deploy_to_single_network(
     })
 }
 
-async fn deploy_to_saved_networks(
+fn deploy_to_saved_networks(
     networks: &[String],
     create_key: &Keypair,
     setup_keypair: &Keypair,
@@ -199,9 +196,7 @@ async fn deploy_to_saved_networks(
             fee_payer_signer,
             members,
             threshold,
-        )
-        .await
-        {
+        ) {
             Ok(deployment) => {
                 deployments.push(deployment);
             }
@@ -224,7 +219,7 @@ async fn deploy_to_saved_networks(
     Ok(deployments)
 }
 
-async fn deploy_to_manual_networks(
+fn deploy_to_manual_networks(
     config: &Config,
     create_key: &Keypair,
     contributor_keypair: &Keypair,
@@ -246,9 +241,7 @@ async fn deploy_to_manual_networks(
             fee_payer_signer,
             members,
             threshold,
-        )
-        .await
-        {
+        ) {
             Ok(deployment) => {
                 deployments.push(deployment);
             }

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -9,7 +9,7 @@ use crate::utils::*;
 use eyre::Result;
 use inquire::{Confirm, Select, Text};
 
-pub async fn interactive_mode() -> Result<()> {
+pub fn interactive_mode() -> Result<()> {
     let mut config = load_config()?;
 
     loop {
@@ -26,17 +26,17 @@ pub async fn interactive_mode() -> Result<()> {
         match choice {
             "Create new feature gate multisig" => {
                 let feepayer_path = prompt_for_fee_payer_path(&config)?;
-                create_command(&mut config, None, Some(feepayer_path)).await?;
+                create_command(&mut config, None, Some(feepayer_path))?;
             }
             "Proposal Actions (Approve/Reject/Execute)" => {
-                handle_proposal_action(&config).await?;
+                handle_proposal_action(&config)?;
             }
             "Show feature gate multisig details" => {
                 let address = Text::new("Enter the main multisig address:").prompt()?;
-                show_command(&config, Some(address)).await?;
+                show_command(&config, Some(address))?;
             }
             "Show configuration" => {
-                config_command(&config).await?;
+                config_command(&config)?;
             }
             "Exit" => break,
             _ => unreachable!(),
@@ -48,7 +48,7 @@ pub async fn interactive_mode() -> Result<()> {
     Ok(())
 }
 
-async fn handle_proposal_action(config: &Config) -> Result<()> {
+fn handle_proposal_action(config: &Config) -> Result<()> {
     println!("In the current setup, only the fee payer keypair is used for transactions, hence for EOA voting fee payer = voting account. For multisig setup, the fee payer needs to be a member of the parent multisig.\n");
 
     // Collect common inputs
@@ -97,8 +97,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                 voting_key,
                 fee_payer_path,
                 kind,
-            )
-            .await;
+            );
         }
 
         let proposal_index_str = Text::new("Enter the proposal index:").prompt()?;
@@ -128,8 +127,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     fee_payer_path,
                     proposal_index,
                     kind,
-                )
-                .await?;
+                )?;
             }
             "Reject" => {
                 reject_common_feature_gate_proposal(
@@ -139,8 +137,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     fee_payer_path,
                     proposal_index,
                     kind,
-                )
-                .await?;
+                )?;
             }
             "Execute" => {
                 execute_common_feature_gate_proposal(
@@ -150,8 +147,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     fee_payer_path,
                     proposal_index,
                     kind,
-                )
-                .await?;
+                )?;
             }
             _ => unreachable!(),
         }
@@ -164,8 +160,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                 feature_gate_multisig_address,
                 voting_key,
                 fee_payer_path,
-            )
-            .await;
+            );
         }
 
         let proposal_index_str = Text::new("Enter the proposal index:").prompt()?;
@@ -191,8 +186,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     voting_key,
                     fee_payer_path,
                     proposal_index,
-                )
-                .await?;
+                )?;
             }
             "Reject" => {
                 let confirmed = Confirm::new(&format!(
@@ -212,8 +206,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     fee_payer_path,
                     proposal_index,
                     TransactionKind::Rekey,
-                )
-                .await?;
+                )?;
             }
             "Execute" => {
                 let confirmed = Confirm::new(&format!(
@@ -232,8 +225,7 @@ async fn handle_proposal_action(config: &Config) -> Result<()> {
                     voting_key,
                     fee_payer_path,
                     proposal_index,
-                )
-                .await?;
+                )?;
             }
             _ => unreachable!(),
         }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -15,7 +15,7 @@ use solana_pubkey::Pubkey;
 use std::str::FromStr;
 use tabled::{settings::Style, Table, Tabled};
 
-pub async fn show_command(config: &Config, address: Option<String>) -> Result<()> {
+pub fn show_command(config: &Config, address: Option<String>) -> Result<()> {
     let address = if let Some(addr) = address {
         // Validate provided address
         match Pubkey::from_str(&addr) {
@@ -32,10 +32,10 @@ pub async fn show_command(config: &Config, address: Option<String>) -> Result<()
     } else {
         validate_pubkey_with_retry("Enter multisig address:")?.to_string()
     };
-    show_multisig(config, &address).await
+    show_multisig(config, &address)
 }
 
-async fn show_multisig(config: &Config, address: &str) -> Result<()> {
+fn show_multisig(config: &Config, address: &str) -> Result<()> {
     // Parse the multisig address
     let multisig_pubkey =
         Pubkey::from_str(address).map_err(|_| eyre::eyre!("Invalid multisig address format"))?;
@@ -115,7 +115,7 @@ async fn show_multisig(config: &Config, address: &str) -> Result<()> {
 
     // Fetch and display transaction and proposal details for all live indices.
     let rpc_client = create_rpc_client(&rpc_url);
-    fetch_and_display_transactions_and_proposals(&rpc_client, &multisig_pubkey, &multisig).await?;
+    fetch_and_display_transactions_and_proposals(&rpc_client, &multisig_pubkey, &multisig)?;
 
     Ok(())
 }
@@ -280,7 +280,7 @@ fn display_multisig_details(multisig: &Multisig, address: &Pubkey) -> Result<()>
     Ok(())
 }
 
-async fn fetch_and_display_transactions_and_proposals(
+fn fetch_and_display_transactions_and_proposals(
     rpc_client: &RpcClient,
     multisig_pubkey: &Pubkey,
     multisig: &Multisig,
@@ -327,7 +327,7 @@ async fn fetch_and_display_transactions_and_proposals(
         println!();
 
         // Fetch transaction account
-        match fetch_and_display_transaction(rpc_client, &transaction_pda, tx_index).await {
+        match fetch_and_display_transaction(rpc_client, &transaction_pda, tx_index) {
             Ok(_) => {}
             Err(e) => {
                 println!(
@@ -339,7 +339,7 @@ async fn fetch_and_display_transactions_and_proposals(
         }
 
         // Fetch proposal account
-        match fetch_and_display_proposal(rpc_client, &proposal_pda, tx_index).await {
+        match fetch_and_display_proposal(rpc_client, &proposal_pda, tx_index) {
             Ok(_) => {}
             Err(e) => {
                 println!(
@@ -362,7 +362,7 @@ enum TransactionType {
     Config(ConfigTransaction),
 }
 
-async fn fetch_and_display_transaction(
+fn fetch_and_display_transaction(
     rpc_client: &RpcClient,
     transaction_pda: &Pubkey,
     tx_index: u64,
@@ -729,7 +729,7 @@ fn display_vault_transaction(transaction: &VaultTransaction, tx_index: u64) {
     println!();
 }
 
-async fn fetch_and_display_proposal(
+fn fetch_and_display_proposal(
     rpc_client: &RpcClient,
     proposal_pda: &Pubkey,
     tx_index: u64,

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -212,7 +212,7 @@ fn confirm_action(prompt: &str, default: bool) -> bool {
 // Orchestrates one parent-multisig action (create/approve/reject/execute); the parameters are
 // independent context (ids, signer, network, operation, payload) that don't form a cohesive group.
 #[allow(clippy::too_many_arguments)]
-async fn handle_parent_multisig_flow(
+fn handle_parent_multisig_flow(
     parent_multisig: Pubkey,
     feature_gate_multisig_address: Pubkey,
     proposal_index: u64,
@@ -531,7 +531,7 @@ async fn handle_parent_multisig_flow(
     Ok(())
 }
 
-pub async fn approve_common_feature_gate_proposal(
+pub fn approve_common_feature_gate_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -547,10 +547,9 @@ pub async fn approve_common_feature_gate_proposal(
         proposal_index,
         ProposalFlavor::Vault(kind),
     )
-    .await
 }
 
-pub async fn reject_common_feature_gate_proposal(
+pub fn reject_common_feature_gate_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -584,8 +583,7 @@ pub async fn reject_common_feature_gate_proposal(
             &rpc_url,
             ProposalAction::Reject,
             ParentFlowPayload::None,
-        )
-        .await;
+        );
     }
 
     let blockhash = rpc_client.get_latest_blockhash()?;
@@ -621,7 +619,7 @@ pub async fn reject_common_feature_gate_proposal(
     Ok(())
 }
 
-pub async fn execute_common_feature_gate_proposal(
+pub fn execute_common_feature_gate_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -669,8 +667,7 @@ pub async fn execute_common_feature_gate_proposal(
                 &rpc_url,
                 ProposalAction::Execute,
                 ParentFlowPayload::None,
-            )
-            .await;
+            );
         }
 
         // Vault transaction execute path
@@ -720,8 +717,7 @@ pub async fn execute_common_feature_gate_proposal(
             &rpc_url,
             ProposalAction::Execute,
             ParentFlowPayload::Execute(child_execution_account_metas),
-        )
-        .await;
+        );
     }
 
     // Permission check: voting_key must be a member with Execute permission on the child multisig
@@ -758,7 +754,7 @@ pub async fn execute_common_feature_gate_proposal(
     Ok(())
 }
 
-pub async fn create_feature_gate_proposal(
+pub fn create_feature_gate_proposal(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -821,8 +817,7 @@ pub async fn create_feature_gate_proposal(
             &rpc_url,
             ProposalAction::Create,
             ParentFlowPayload::Create(vault_tx_message),
-        )
-        .await?;
+        )?;
 
         output::Output::field(
             "Vault proposal created at index:",
@@ -881,7 +876,7 @@ pub async fn create_feature_gate_proposal(
     Ok(())
 }
 
-pub async fn rekey_multisig_feature_gate(
+pub fn rekey_multisig_feature_gate(
     config: &Config,
     feature_gate_multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -966,8 +961,7 @@ pub async fn rekey_multisig_feature_gate(
             &rpc_url,
             ProposalAction::Create,
             ParentFlowPayload::Create(child_tx_message?),
-        )
-        .await;
+        );
     }
 
     // EOA voting path - create config transaction and proposal
@@ -1049,8 +1043,7 @@ pub async fn rekey_multisig_feature_gate(
             voting_key,
             fee_payer_path,
             next_tx_index,
-        )
-        .await?;
+        )?;
     }
 
     output::Output::info(
@@ -1059,7 +1052,7 @@ pub async fn rekey_multisig_feature_gate(
     Ok(())
 }
 
-pub async fn approve_common_config_change(
+pub fn approve_common_config_change(
     config: &Config,
     multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -1074,10 +1067,9 @@ pub async fn approve_common_config_change(
         transaction_index,
         ProposalFlavor::Config,
     )
-    .await
 }
 
-async fn approve_common_proposal(
+fn approve_common_proposal(
     config: &Config,
     multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -1113,8 +1105,7 @@ async fn approve_common_proposal(
             &rpc_url,
             ProposalAction::Approve,
             ParentFlowPayload::None,
-        )
-        .await;
+        );
     }
 
     // EOA voting path - approve proposal
@@ -1162,7 +1153,7 @@ async fn approve_common_proposal(
     Ok(())
 }
 
-pub async fn execute_common_config_change(
+pub fn execute_common_config_change(
     config: &Config,
     multisig_address: Pubkey,
     voting_key: Pubkey,
@@ -1200,8 +1191,7 @@ pub async fn execute_common_config_change(
             &rpc_url,
             ProposalAction::Execute,
             ParentFlowPayload::None,
-        )
-        .await;
+        );
     }
 
     // Permission check: voting_key must be a member with Execute permission on the multisig

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,13 +87,12 @@ The contributor key receives Initiate-only permissions, while additional members
     Config,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Some(command) => handle_command(command).await,
-        None => interactive_mode().await,
+        Some(command) => handle_command(command),
+        None => interactive_mode(),
     };
 
     if let Err(e) = result {
@@ -119,7 +118,7 @@ async fn main() {
     }
 }
 
-async fn handle_command(command: Commands) -> Result<()> {
+fn handle_command(command: Commands) -> Result<()> {
     let mut config = load_config()?;
 
     match command {
@@ -136,10 +135,10 @@ async fn handle_command(command: Commands) -> Result<()> {
                 }
             });
 
-            create_command(&mut config, threshold_option, keypair).await
+            create_command(&mut config, threshold_option, keypair)
         }
-        Commands::Show { address } => show_command(&config, address).await,
-        Commands::Interactive => interactive_mode().await,
-        Commands::Config => config_command(&config).await,
+        Commands::Show { address } => show_command(&config, address),
+        Commands::Interactive => interactive_mode(),
+        Commands::Config => config_command(&config),
     }
 }

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -274,7 +274,7 @@ pub fn get_account_data_with_retry(
             .unwrap_or_else(|| "Unknown error".to_string())
     ))
 }
-pub async fn create_multisig(
+pub fn create_multisig(
     rpc_url: String,
     fee_payer_keypair: &dyn Signer,
     create_key: &Keypair,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -377,7 +377,7 @@ fn create_child_vote_transaction_message(
 ///
 /// # Returns
 /// Result containing the transaction signature or an error
-pub async fn create_and_send_funding_transaction(
+pub fn create_and_send_funding_transaction(
     rpc_url: &str,
     fee_payer_signer: &dyn Signer,
     feature_gate_address: &Pubkey,
@@ -688,7 +688,7 @@ pub fn decode_permissions(mask: u8) -> Vec<String> {
 
 /// Check that the fee payer has sufficient SOL balance on all networks
 /// Returns a Result indicating success or failure with network-specific errors
-pub async fn check_fee_payer_balance_on_networks(
+pub fn check_fee_payer_balance_on_networks(
     fee_payer_pubkey: &Pubkey,
     networks: &[String],
     required_balance_sol: f64,

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -54,12 +54,16 @@ struct Fixture {
 
 static FIXTURE: OnceCell<Fixture> = OnceCell::new();
 
-async fn build_fixture() -> Fixture {
+fn build_fixture() -> Fixture {
     // Enable non-interactive mode for E2E tests
     std::env::set_var("E2E_TEST_MODE", "1");
     std::env::set_var("RUST_LOG", "info");
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
+
+    // surfpool clones the Squads program from mainnet on startup; wait for it
+    // before transacting, otherwise the first creations race the clone and fail.
+    wait_for_account(&client, &SQUADS_MULTISIG_PROGRAM_ID);
 
     // Step 1: Create three parent multisigs
     let mut parent_multisigs = Vec::new();
@@ -83,7 +87,6 @@ async fn build_fixture() -> Fixture {
         let create_key = Keypair::new();
         let (multisig_pda, _signature) =
             create_multisig(rpc_url(), &creator, &create_key, members, 1, None)
-                .await
                 .expect("create parent multisig");
 
         let vault_pda = get_vault_pda(&multisig_pda, 0).0;
@@ -154,7 +157,6 @@ async fn build_fixture() -> Fixture {
         Some(3),
         Some(fee_payer_path.to_string_lossy().to_string()),
     )
-    .await
     .expect("create feature gate via create_command");
 
     let deployment = deployments.first().expect("deployment result should exist");
@@ -181,18 +183,25 @@ async fn build_fixture() -> Fixture {
     }
 }
 
-async fn get_fixture() -> &'static Fixture {
-    if let Some(f) = FIXTURE.get() {
-        return f;
-    }
-    let fixture = build_fixture().await;
-    let _ = FIXTURE.set(fixture);
-    FIXTURE.get().expect("fixture should be set")
+fn get_fixture() -> &'static Fixture {
+    FIXTURE.get_or_init(build_fixture)
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_1_activate_feature_gate() {
-    let fixture = get_fixture().await;
+/// Poll until `address` is readable, giving surfpool time to clone mainnet
+/// accounts/programs on startup. Panics if it never appears.
+fn wait_for_account(client: &RpcClient, address: &Pubkey) {
+    for _ in 0..60 {
+        if client.get_account(address).is_ok() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    panic!("surfpool did not load account {address} within 30s");
+}
+
+#[test]
+fn rpc_e2e_1_activate_feature_gate() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -216,7 +225,6 @@ async fn rpc_e2e_1_activate_feature_gate() {
             proposal_index,
             TransactionKind::Activate,
         )
-        .await
         .expect("approve proposal");
 
         println!("✅ Approver {} approved proposal", i + 1);
@@ -233,7 +241,6 @@ async fn rpc_e2e_1_activate_feature_gate() {
         proposal_index,
         TransactionKind::Activate,
     )
-    .await
     .expect("execute proposal");
 
     println!("✅ Feature gate activated");
@@ -271,9 +278,9 @@ async fn rpc_e2e_1_activate_feature_gate() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_2_revoke_feature_gate() {
-    let fixture = get_fixture().await;
+#[test]
+fn rpc_e2e_2_revoke_feature_gate() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -318,7 +325,6 @@ async fn rpc_e2e_2_revoke_feature_gate() {
         fixture.parent_key_paths[0].clone(),
         TransactionKind::Revoke,
     )
-    .await
     .expect("create revoke proposal dynamically");
 
     println!(
@@ -363,7 +369,6 @@ async fn rpc_e2e_2_revoke_feature_gate() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("parent[0] approves revoke proposal");
 
     approve_common_feature_gate_proposal(
@@ -374,7 +379,6 @@ async fn rpc_e2e_2_revoke_feature_gate() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("EOA approves revoke proposal");
 
     approve_common_feature_gate_proposal(
@@ -385,7 +389,6 @@ async fn rpc_e2e_2_revoke_feature_gate() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("parent[2] approves revoke proposal");
 
     println!("✅ Revocation approved with 3 approvals!");
@@ -421,7 +424,6 @@ async fn rpc_e2e_2_revoke_feature_gate() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("execute revoke proposal");
 
     println!("✅ Revocation executed!");
@@ -440,9 +442,9 @@ async fn rpc_e2e_2_revoke_feature_gate() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_3_reject_activation() {
-    let fixture = get_fixture().await;
+#[test]
+fn rpc_e2e_3_reject_activation() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -468,7 +470,6 @@ async fn rpc_e2e_3_reject_activation() {
         fixture.parent_key_paths[0].clone(),
         TransactionKind::Activate,
     )
-    .await
     .expect("create activation proposal for rejection");
 
     println!(
@@ -490,7 +491,6 @@ async fn rpc_e2e_3_reject_activation() {
         proposal_index,
         TransactionKind::Activate,
     )
-    .await
     .expect("reject activation proposal by parent");
     println!("✅ Parent 1 rejected proposal");
 
@@ -503,7 +503,6 @@ async fn rpc_e2e_3_reject_activation() {
         proposal_index,
         TransactionKind::Activate,
     )
-    .await
     .expect("reject activation proposal by eoa");
     println!("✅ EOA member rejected proposal");
 
@@ -542,9 +541,9 @@ async fn rpc_e2e_3_reject_activation() {
     println!("✅ Feature gate rejection E2E test completed successfully!");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_4_reject_revocation() {
-    let fixture = get_fixture().await;
+#[test]
+fn rpc_e2e_4_reject_revocation() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -570,7 +569,6 @@ async fn rpc_e2e_4_reject_revocation() {
         fixture.parent_key_paths[2].clone(),
         TransactionKind::Revoke,
     )
-    .await
     .expect("create revocation proposal for rejection");
 
     println!(
@@ -593,7 +591,6 @@ async fn rpc_e2e_4_reject_revocation() {
         proposal_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("reject revocation proposal by parent");
     println!("✅ Parent 1 rejected revocation proposal");
 
@@ -605,7 +602,6 @@ async fn rpc_e2e_4_reject_revocation() {
         proposal_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("reject revocation proposal by eoa");
     println!("✅ EOA member rejected revocation proposal");
 
@@ -644,9 +640,9 @@ async fn rpc_e2e_4_reject_revocation() {
     println!("✅ Feature gate revocation rejection E2E test completed successfully!");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_5_reject_rekey() {
-    let fixture = get_fixture().await;
+#[test]
+fn rpc_e2e_5_reject_rekey() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -673,7 +669,6 @@ async fn rpc_e2e_5_reject_rekey() {
             fixture.parent_multisigs[0],
             fixture.parent_key_paths[0].clone(),
         )
-        .await
         .expect("create rekey proposal for rejection");
 
         println!(
@@ -694,7 +689,6 @@ async fn rpc_e2e_5_reject_rekey() {
         proposal_index,
         TransactionKind::Rekey,
     )
-    .await
     .expect("reject rekey proposal by parent");
     println!("✅ Parent 2 rejected rekey proposal");
 
@@ -707,7 +701,6 @@ async fn rpc_e2e_5_reject_rekey() {
         proposal_index,
         TransactionKind::Rekey,
     )
-    .await
     .expect("reject rekey proposal by eoa");
     println!("✅ EOA member rejected rekey proposal");
 
@@ -742,9 +735,9 @@ async fn rpc_e2e_5_reject_rekey() {
     println!("✅ Rekey rejection E2E test completed successfully!");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_6_rekey_feature_gate_multisig() {
-    let fixture = get_fixture().await;
+#[test]
+fn rpc_e2e_6_rekey_feature_gate_multisig() {
+    let fixture = get_fixture();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
 
@@ -772,7 +765,6 @@ async fn rpc_e2e_6_rekey_feature_gate_multisig() {
             fixture.parent_multisigs[3],
             fixture.parent_key_paths[3].clone(),
         )
-        .await
         .expect("create rekey proposal via parent multisig");
 
         println!(
@@ -794,7 +786,6 @@ async fn rpc_e2e_6_rekey_feature_gate_multisig() {
             proposal_index,
             TransactionKind::Rekey,
         )
-        .await
         .expect("approve rekey proposal");
 
         println!("✅ Approver {} approved rekey proposal", i + 1);
@@ -811,7 +802,6 @@ async fn rpc_e2e_6_rekey_feature_gate_multisig() {
         proposal_index,
         TransactionKind::Rekey,
     )
-    .await
     .expect("execute rekey proposal");
 
     println!("✅ Rekey executed");
@@ -846,8 +836,8 @@ async fn rpc_e2e_6_rekey_feature_gate_multisig() {
 /// Test 7: EOA approves and executes an activation proposal
 /// This test creates a new child multisig with EOA-only members using the real CLI flow,
 /// then EOAs approve and execute the pre-created activation proposal.
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_7_eoa_activation_flow() {
+#[test]
+fn rpc_e2e_7_eoa_activation_flow() {
     // Enable non-interactive mode
     std::env::set_var("E2E_TEST_MODE", "1");
 
@@ -892,7 +882,6 @@ async fn rpc_e2e_7_eoa_activation_flow() {
         Some(2), // threshold
         Some(eoa_keypaths[0].clone()),
     )
-    .await
     .expect("create feature gate via CLI");
 
     let deployment = deployments.first().expect("deployment should exist");
@@ -918,7 +907,6 @@ async fn rpc_e2e_7_eoa_activation_flow() {
         1, // proposal index
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[0] approves activation");
 
     println!("✅ EOA[0] approved activation proposal (1/2)");
@@ -932,7 +920,6 @@ async fn rpc_e2e_7_eoa_activation_flow() {
         1, // proposal index
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[1] approves activation");
 
     println!("✅ EOA[1] approved activation proposal (2/2)");
@@ -961,7 +948,6 @@ async fn rpc_e2e_7_eoa_activation_flow() {
         1,
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[1] executes activation");
 
     println!("✅ EOA[1] executed activation proposal");
@@ -999,8 +985,8 @@ async fn rpc_e2e_7_eoa_activation_flow() {
 /// Test 8: EOA creates and executes a revocation proposal
 /// Uses the same CLI flow as test 7 - creates multisig via create_command_with_deployments,
 /// then activates, then creates and executes revocation.
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_e2e_8_eoa_revocation_flow() {
+#[test]
+fn rpc_e2e_8_eoa_revocation_flow() {
     // Enable non-interactive mode
     std::env::set_var("E2E_TEST_MODE", "1");
 
@@ -1045,7 +1031,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         Some(2), // threshold
         Some(eoa_keypaths[0].clone()),
     )
-    .await
     .expect("create feature gate via CLI");
 
     let deployment = deployments.first().expect("deployment should exist");
@@ -1071,7 +1056,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         1,
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[0] approves activation");
 
     // EOA[1] approves the activation proposal
@@ -1083,7 +1067,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         1,
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[1] approves activation");
 
     // EOA[1] executes the activation
@@ -1095,7 +1078,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         1,
         TransactionKind::Activate,
     )
-    .await
     .expect("EOA[1] executes activation");
 
     println!("✅ Feature gate activated (prerequisite for revocation)");
@@ -1122,7 +1104,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         eoa_keypaths[2].clone(),
         TransactionKind::Revoke,
     )
-    .await
     .expect("EOA[2] creates revocation proposal");
 
     println!(
@@ -1140,7 +1121,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("EOA[2] approves revocation");
 
     approve_common_feature_gate_proposal(
@@ -1151,7 +1131,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("EOA[0] approves revocation");
 
     println!("✅ Revocation proposal approved with 2 approvals");
@@ -1180,7 +1159,6 @@ async fn rpc_e2e_8_eoa_revocation_flow() {
         revocation_index,
         TransactionKind::Revoke,
     )
-    .await
     .expect("EOA[2] executes revocation");
 
     println!("✅ EOA[2] executed revocation proposal");


### PR DESCRIPTION
The codebase was async-shaped but never actually async. Every `.await` just called another internal `async fn`, all the real I/O goes through the blocking `RpcClient`, and there's no `spawn`/`join`/`select` anywhere. So this rips it all out:

- 37 `async fn` became `fn`, ~80 `.await` removed
- `#[tokio::main]` became a plain `fn main()`, `#[tokio::test]` became `#[test]`
- `tokio` removed from `Cargo.toml`
