### PR TITLE
Cleanups

### DIFF
--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -90,11 +90,7 @@ fn build_config_actions_for_kind(
             actions.push(crate::squads::ConfigAction::AddMember {
                 new_member: crate::squads::Member {
                     key: Pubkey::default(),
-                    permissions: crate::squads::Permissions {
-                        mask: (crate::squads::Permission::Initiate as u8)
-                            | (crate::squads::Permission::Vote as u8)
-                            | (crate::squads::Permission::Execute as u8),
-                    },
+                    permissions: crate::squads::Permissions::all(),
                 },
             });
 

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -188,7 +188,7 @@ fn verify_member_permission(
 
 /// Interactive confirmation - auto-confirms in E2E test mode
 fn confirm_action(prompt: &str, default: bool) -> bool {
-    if std::env::var("E2E_TEST_MODE").is_ok() {
+    if crate::utils::is_e2e_test_mode() {
         return true;
     }
     Confirm::new(prompt)
@@ -896,7 +896,7 @@ pub fn rekey_multisig_feature_gate(
     }
 
     // Final confirmation
-    if std::env::var("E2E_TEST_MODE").is_err() {
+    if !crate::utils::is_e2e_test_mode() {
         let confirm =
             Confirm::new("This will permanently disable voting on this multisig. Are you sure?")
                 .with_default(false)

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -684,28 +684,8 @@ pub fn execute_common_feature_gate_proposal(
         )?;
         let child_transaction_message = child_transaction_contents.message;
 
-        // Build execution account metas from the child transaction
-        let mut child_execution_account_metas = Vec::new();
-        for (i, account_key) in child_transaction_message.account_keys.iter().enumerate() {
-            // Preserve writability but do NOT mark any of the child execution
-            // accounts as signers. The Squads program will derive the required
-            // signer PDA(s) from the stored transaction message, and marking
-            // them as signers in the outer Execute instruction confuses the
-            // account grouping (leading to InvalidAccount during CPI).
-            let is_signer = false;
-            let is_writable = child_transaction_message.is_static_writable_index(i);
-            if is_writable {
-                child_execution_account_metas.push(solana_instruction::AccountMeta::new(
-                    *account_key,
-                    is_signer,
-                ));
-            } else {
-                child_execution_account_metas.push(solana_instruction::AccountMeta::new_readonly(
-                    *account_key,
-                    is_signer,
-                ));
-            }
-        }
+        // Build execution account metas from the child transaction.
+        let child_execution_account_metas = child_transaction_message.execution_account_metas();
 
         return handle_parent_multisig_flow(
             voting_key,

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -869,23 +869,9 @@ pub fn create_execute_transaction_message(
     .map_err(|e| eyre::eyre!("at {}: {}", transaction_pda, e))?;
     let transaction_message = transaction_contents.message;
 
-    let mut execution_account_metas = Vec::new();
-    for (i, account_key) in transaction_message.account_keys.iter().enumerate() {
-        // Do NOT preserve signer flags in the outer instruction. The Squads program
-        // reads the stored TransactionMessage which has num_signers to know which accounts
-        // to PDA-sign during CPI. Marking them as signers here causes message construction issues.
-        let is_signer = false;
-
-        let is_writable = transaction_message.is_static_writable_index(i);
-        if is_writable {
-            execution_account_metas.push(AccountMeta::new(*account_key, is_signer));
-        } else {
-            execution_account_metas.push(AccountMeta::new_readonly(*account_key, is_signer));
-        }
-    }
-
     // All accounts from the stored message are passed through to the Squads program,
     // including the parent multisig needed for vault PDA derivation during CPI.
+    let execution_account_metas = transaction_message.execution_account_metas();
 
     let account_keys = MultisigExecuteTransactionAccounts {
         multisig: *multisig_address,

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -354,7 +354,7 @@ pub fn create_multisig(
     );
     println!();
 
-    let proceed = if std::env::var("E2E_TEST_MODE").is_ok() {
+    let proceed = if crate::utils::is_e2e_test_mode() {
         true
     } else {
         Confirm::new("Do you want to proceed?")

--- a/src/squads.rs
+++ b/src/squads.rs
@@ -106,13 +106,6 @@ pub struct Member {
     pub permissions: Permissions,
 }
 
-#[derive(Clone, Copy)]
-pub enum Permission {
-    Initiate = 1 << 0,
-    Vote = 1 << 1,
-    Execute = 1 << 2,
-}
-
 /// Permission bit constants for checking member permissions
 pub const PERMISSION_INITIATE: u8 = 1 << 0;
 pub const PERMISSION_VOTE: u8 = 1 << 1;
@@ -121,6 +114,15 @@ pub const PERMISSION_EXECUTE: u8 = 1 << 2;
 #[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Clone, Copy, Default, Debug)]
 pub struct Permissions {
     pub mask: u8,
+}
+
+impl Permissions {
+    /// All permissions: Initiate + Vote + Execute.
+    pub const fn all() -> Self {
+        Self {
+            mask: PERMISSION_INITIATE | PERMISSION_VOTE | PERMISSION_EXECUTE,
+        }
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq)]

--- a/src/squads.rs
+++ b/src/squads.rs
@@ -198,6 +198,26 @@ impl VaultTransactionMessage {
 
         false
     }
+
+    /// Account metas for passing this stored message's accounts through to an
+    /// `ExecuteTransaction` instruction, preserving writability.
+    ///
+    /// None are marked as signers on purpose: the Squads program derives the
+    /// required signer PDA(s) from the stored message during CPI, and marking
+    /// them as signers in the outer instruction breaks account grouping.
+    pub fn execution_account_metas(&self) -> Vec<AccountMeta> {
+        self.account_keys
+            .iter()
+            .enumerate()
+            .map(|(i, key)| {
+                if self.is_static_writable_index(i) {
+                    AccountMeta::new(*key, false)
+                } else {
+                    AccountMeta::new_readonly(*key, false)
+                }
+            })
+            .collect()
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,7 @@ pub fn parse_saved_members(config: &Config) -> Vec<Member> {
             Ok(pubkey) => {
                 parsed_members.push(Member {
                     key: pubkey,
-                    permissions: Permissions { mask: 7 }, // Full permissions for saved members
+                    permissions: Permissions::all(), // Full permissions for saved members
                 });
             }
             Err(_) => {
@@ -141,7 +141,7 @@ pub fn collect_members_interactively() -> Result<Vec<Member>> {
             Ok(member_key) => {
                 interactive_members.push(Member {
                     key: member_key,
-                    permissions: Permissions { mask: 7 },
+                    permissions: Permissions::all(),
                 });
                 println!(
                     "  {} Added member: {} ({})",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,6 +52,12 @@ pub struct DeploymentResult {
     pub transaction_signature: String,
 }
 
+/// True when running under the E2E test harness, which auto-confirms prompts
+/// and picks defaults non-interactively.
+pub fn is_e2e_test_mode() -> bool {
+    std::env::var("E2E_TEST_MODE").is_ok()
+}
+
 /// Returns a human-readable network name based on the RPC URL.
 pub fn get_network_display(rpc_url: &str) -> &'static str {
     if rpc_url.contains("devnet") {
@@ -543,7 +549,7 @@ pub fn choose_network_from_config(config: &Config) -> Result<String> {
     }
 
     // Non-interactive mode for E2E tests
-    if std::env::var("E2E_TEST_MODE").is_ok() {
+    if is_e2e_test_mode() {
         return Ok(available_networks[0].to_string());
     }
 
@@ -584,7 +590,7 @@ pub fn choose_network_mode(config: &Config, use_saved_config: bool) -> Result<(b
         );
     }
     // Auto-confirm in E2E test mode
-    let use_saved_networks = if std::env::var("E2E_TEST_MODE").is_ok() {
+    let use_saved_networks = if is_e2e_test_mode() {
         true
     } else {
         Confirm::new("Use saved networks for deployment?")
@@ -661,7 +667,7 @@ pub fn review_config(config: &Config) -> Result<bool> {
 
     println!();
     // Auto-confirm in E2E test mode
-    let use_config = if std::env::var("E2E_TEST_MODE").is_ok() {
+    let use_config = if is_e2e_test_mode() {
         true
     } else {
         Confirm::new("Use these saved members and settings?")

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -24,7 +24,7 @@ use feature_gate_multisig_tool::feature_gate_program::{
 };
 use feature_gate_multisig_tool::provision::create_multisig;
 use feature_gate_multisig_tool::squads::{
-    get_proposal_pda, get_vault_pda, Member, Permission, Permissions, Proposal, ProposalStatus,
+    get_proposal_pda, get_vault_pda, Member, Permissions, Proposal, ProposalStatus,
     SQUADS_MULTISIG_PROGRAM_ID,
 };
 use feature_gate_multisig_tool::utils::Config;
@@ -34,9 +34,7 @@ fn rpc_url() -> String {
 }
 
 fn full_permissions() -> Permissions {
-    Permissions {
-        mask: (Permission::Initiate as u8) | (Permission::Vote as u8) | (Permission::Execute as u8),
-    }
+    Permissions::all()
 }
 
 struct Fixture {


### PR DESCRIPTION
- **Dedupe execution account-metas.** The EOA and parent execute paths built the same passthrough `AccountMeta` list from a stored vault transaction. Pulled it into a `VaultTransactionMessage::execution_account_metas()` method.
- **Unify permissions.** There were three ways to say "full permissions" (the `Permission` enum, the `PERMISSION_*` consts, and a magic `mask: 7`). Added `Permissions::all()`, used it everywhere, and deleted the now-unused `Permission` enum.
- **Centralize the E2E test-mode check.** Replaced six scattered `std::env::var("E2E_TEST_MODE")` checks with a single `is_e2e_test_mode()` helper.
