### PR TITLE
clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,16 @@ solana-rpc-client-api = "2.0.0"
 once_cell = "1.19"
 
 [lints.clippy]
-# Catch debugging/placeholder leftovers. Wider pedantic adoption is deferred
-# (~260 findings) — track separately.
+# Panic prevention: production code must not crash on bad input or RPC errors.
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+panic_in_result_fn = "deny"
+# Code hygiene: no debugging or placeholder leftovers.
 dbg_macro = "deny"
 todo = "deny"
 unimplemented = "deny"
+# Safety.
+exit = "deny"
+mem_forget = "deny"
+# Wider pedantic adoption is deferred (~260 findings) — track separately.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+// unwrap/expect/panic are idiomatic in unit tests; the panic-prevention lints
+// stay strict for production code only.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::panic_in_result_fn
+    )
+)]
+
 pub mod commands;
 pub mod constants;
 pub mod feature_gate_program;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,15 @@
+// unwrap/expect/panic are idiomatic in unit tests; the panic-prevention lints
+// stay strict for production code only.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::panic_in_result_fn
+    )
+)]
+
 mod commands;
 mod constants;
 mod feature_gate_program;

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -1,6 +1,15 @@
 //! RPC-based E2E tests against a running surfpool instance.
 //! Run `surfpool start` first, which will load Squads BPF and start a local validator.
 
+// unwrap/expect/panic are idiomatic in tests; the panic-prevention lints apply
+// to production code only.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn
+)]
+
 use std::env;
 use std::path::PathBuf;
 


### PR DESCRIPTION
Bumps the clippy config from three lints to a real panic prevention set so production code can't crash on bad input or RPC errors.