### PR TITLE
Pin dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
       # --all-targets compile-checks the E2E tests too; they need a live surfpool
       # validator to run, so they are not executed here.
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       # Plain `cargo test` must be self-contained: the surfpool E2E tests are
       # #[ignore]d and only run via `make test-surfpool` (the e2e job).
       - name: Unit tests
-        run: cargo test
+        run: cargo test --locked
 
   deny:
     name: cargo-deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,35 +9,38 @@ repository = "https://github.com/Squads-Protocol/feature-gate-multisig"
 keywords = ["solana", "multisig", "governance", "feature-gates", "blockchain"]
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
+# Direct dependencies are pinned exactly (`=`): this tool signs governance
+# transactions, so versions must only move through reviewed bumps, never through
+# an incidental `cargo update` or a fresh unlocked resolution.
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
-inquire = "0.9"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dirs = "6.0"
-borsh = "1.5.7"
-colored = "3.1.1"
-indicatif = "0.18.6"
-eyre = "0.6.12"
-tabled = "0.21"
+clap = { version = "=4.6.1", features = ["derive"] }
+inquire = "=0.9.4"
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.150"
+dirs = "=6.0.0"
+borsh = "=1.7.0"
+colored = "=3.1.1"
+indicatif = "=0.18.6"
+eyre = "=0.6.12"
+tabled = "=0.21.0"
 
-solana-rpc-client = "3.0.14"
-solana-rpc-client-api = "3.0.14"
-solana-clap-v3-utils = "3.0.14"
-solana-instruction = {version = "3.4.0", features = ["bincode"]}
-solana-pubkey = {version = "4.2.0", features = ["borsh", "curve25519"]}
-solana-keypair = "3.1.2"
-solana-signer = "3.0.1"
-solana-message = "3.1.0"
-solana-transaction = {version = "3.1.0", features = ["serde", "bincode"]}
-solana-compute-budget-interface = "3.0.0"
-solana-system-interface = {version = "3.2.0", features = ["bincode"]}
-solana-commitment-config = "3.1.1"
-solana-hash = "4.4.0"
-solana-sha256-hasher = "3.1.0"
+solana-rpc-client = "=3.1.14"
+solana-rpc-client-api = "=3.1.14"
+solana-clap-v3-utils = "=3.1.14"
+solana-instruction = {version = "=3.4.0", features = ["bincode"]}
+solana-pubkey = {version = "=4.2.0", features = ["borsh", "curve25519"]}
+solana-keypair = "=3.1.2"
+solana-signer = "=3.0.1"
+solana-message = "=3.1.0"
+solana-transaction = {version = "=3.1.0", features = ["serde", "bincode"]}
+solana-compute-budget-interface = "=3.0.0"
+solana-system-interface = {version = "=3.2.0", features = ["bincode"]}
+solana-commitment-config = "=3.1.1"
+solana-hash = "=4.5.0"
+solana-sha256-hasher = "=3.1.0"
 
 [dev-dependencies]
-once_cell = "1.19"
+once_cell = "=1.21.4"
 
 [lints.clippy]
 # Panic prevention: production code must not crash on bad input or RPC errors.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-surfpool:
 		surfpool_pid=$$!; \
 		sleep 5; \
 		echo "Running RPC E2E tests..."; \
-		RPC_URL=http://127.0.0.1:8899 cargo test rpc_e2e_ -- --test-threads=1 --nocapture --include-ignored; \
+		RPC_URL=http://127.0.0.1:8899 cargo test --locked rpc_e2e_ -- --test-threads=1 --nocapture --include-ignored; \
 		status=$$?; \
 		echo "Stopping surfpool..."; \
 		kill -KILL "$$surfpool_pid" 2>/dev/null || true; \


### PR DESCRIPTION
This tool signs governance transactions, so dependency versions should only move through reviewed bumps, never through an incidental `cargo update` or a fresh unlocked resolution (`cargo install` without `--locked` ignores lockfiles).

- All direct dependencies in Cargo.toml are now pinned exactly (`=x.y.z`) to the versions the lockfile already resolves. No lockfile change.
- CI clippy/test and the Makefile E2E target run with `--locked`, so a stale or bypassed lockfile fails the build instead of silently re-resolving.
