### PR TITLE
Proposal subcommands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod create;
 pub mod interactive;
+pub mod proposal;
 pub mod show;
 pub mod transaction_generation;
 pub mod verify;
@@ -8,6 +9,7 @@ pub mod verify;
 pub use config::config_command;
 pub use create::create_command;
 pub use interactive::interactive_mode;
+pub use proposal::{proposal_command, ProposalCommand, ProposalCommandArgs};
 pub use show::show_command;
 pub use transaction_generation::*;
 pub use verify::verify_command;

--- a/src/commands/proposal.rs
+++ b/src/commands/proposal.rs
@@ -1,0 +1,128 @@
+//! Non-interactive proposal subcommands: `propose`, `approve`, `reject`,
+//! `execute`. Thin argument-resolution wrappers over the same flow functions
+//! the interactive menu uses, so signers can act from a runbook one-liner.
+
+use crate::commands::transaction_generation::{
+    approve_common_config_change, approve_common_feature_gate_proposal,
+    create_feature_gate_proposal, execute_common_config_change,
+    execute_common_feature_gate_proposal, reject_common_feature_gate_proposal,
+    rekey_multisig_feature_gate, TransactionKind,
+};
+use crate::output::Output;
+use crate::utils::{
+    is_assume_yes, is_e2e_test_mode, prompt_for_fee_payer_path, prompt_for_pubkey, save_config,
+    Config,
+};
+use eyre::Result;
+use solana_pubkey::Pubkey;
+use std::str::FromStr;
+
+/// Which proposal action a subcommand performs.
+#[derive(Debug, Clone, Copy)]
+pub enum ProposalCommand {
+    Propose,
+    Approve,
+    Reject,
+    Execute,
+}
+
+/// Resolved inputs shared by every proposal subcommand.
+pub struct ProposalCommandArgs {
+    pub multisig: String,
+    pub kind: TransactionKind,
+    /// Voting key flag; falls back to the config default, then to a prompt.
+    pub voting_key: Option<String>,
+    /// Fee payer keypair path flag; falls back to the config default, then to a prompt.
+    pub keypair: Option<String>,
+    /// Proposal index (required for approve/reject/execute; unused for propose).
+    pub index: Option<u64>,
+}
+
+pub fn proposal_command(
+    config: &Config,
+    command: ProposalCommand,
+    args: ProposalCommandArgs,
+) -> Result<()> {
+    let multisig = Pubkey::from_str(&args.multisig)
+        .map_err(|_| eyre::eyre!("Invalid multisig address: {}", args.multisig))?;
+    let voting_key = resolve_voting_key(config, args.voting_key.as_deref())?;
+    let fee_payer_path = match args.keypair {
+        Some(path) => path,
+        None => prompt_for_fee_payer_path(config)?,
+    };
+
+    let index = || {
+        args.index.ok_or_else(|| {
+            eyre::eyre!("--index is required: the proposal index to act on (see `show`)")
+        })
+    };
+
+    match (command, args.kind) {
+        (ProposalCommand::Propose, TransactionKind::Rekey) => {
+            rekey_multisig_feature_gate(config, multisig, voting_key, fee_payer_path)
+        }
+        (ProposalCommand::Propose, kind) => {
+            create_feature_gate_proposal(config, multisig, voting_key, fee_payer_path, kind)
+        }
+        (ProposalCommand::Approve, TransactionKind::Rekey) => {
+            approve_common_config_change(config, multisig, voting_key, fee_payer_path, index()?)
+        }
+        (ProposalCommand::Approve, kind) => approve_common_feature_gate_proposal(
+            config,
+            multisig,
+            voting_key,
+            fee_payer_path,
+            index()?,
+            kind,
+        ),
+        (ProposalCommand::Reject, kind) => reject_common_feature_gate_proposal(
+            config,
+            multisig,
+            voting_key,
+            fee_payer_path,
+            index()?,
+            kind,
+        ),
+        (ProposalCommand::Execute, TransactionKind::Rekey) => {
+            execute_common_config_change(config, multisig, voting_key, fee_payer_path, index()?)
+        }
+        (ProposalCommand::Execute, kind) => execute_common_feature_gate_proposal(
+            config,
+            multisig,
+            voting_key,
+            fee_payer_path,
+            index()?,
+            kind,
+        ),
+    }
+}
+
+/// Resolve the voting key: explicit flag, then the config default, then a prompt.
+/// A key obtained interactively is offered to be saved, since a signer's identity
+/// is stable across the many feature gate multisigs they act on.
+fn resolve_voting_key(config: &Config, flag: Option<&str>) -> Result<Pubkey> {
+    if let Some(key) = flag {
+        return Pubkey::from_str(key).map_err(|_| eyre::eyre!("Invalid voting key: {}", key));
+    }
+    if let Some(saved) = &config.voting_key {
+        let key = Pubkey::from_str(saved)
+            .map_err(|_| eyre::eyre!("Saved voting key in config is invalid: {}", saved))?;
+        Output::info(&format!("Using saved voting key: {key}"));
+        return Ok(key);
+    }
+
+    let key = prompt_for_pubkey("Enter the voting key (EOA or parent multisig):")?;
+    if !is_e2e_test_mode()
+        && !is_assume_yes()
+        && inquire::Confirm::new("Save as default voting key for future commands?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+    {
+        let mut updated = config.clone();
+        updated.voting_key = Some(key.to_string());
+        save_config(&updated)?;
+        Output::success("Voting key saved to config.");
+    }
+    Ok(key)
+}

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -197,10 +197,15 @@ fn require_eoa_voting_key_matches_fee_payer(voting_key: &Pubkey, fee_payer: &Pub
     Ok(())
 }
 
-/// Interactive confirmation - auto-confirms in E2E test mode
+/// Interactive confirmation - auto-confirms in E2E test mode. With `--yes`,
+/// resolves to the prompt's default answer, so safety prompts that default to
+/// "no" still abort rather than being force-approved.
 fn confirm_action(prompt: &str, default: bool) -> bool {
     if crate::utils::is_e2e_test_mode() {
         return true;
+    }
+    if crate::utils::is_assume_yes() {
+        return default;
     }
     Confirm::new(prompt)
         .with_default(default)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,12 @@ mod utils;
 mod verification;
 
 use crate::commands::{
-    config_command, create_command, interactive_mode, show_command, verify_command,
+    config_command, create_command, interactive_mode, proposal_command, show_command,
+    verify_command, ProposalCommand, ProposalCommandArgs, TransactionKind,
 };
 use crate::output::Output;
 use crate::utils::load_config;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use colored::*;
 use eyre::Result;
 
@@ -96,6 +97,44 @@ The contributor key receives Initiate-only permissions, while additional members
         #[arg(help = "The feature gate multisig address to verify")]
         address: Option<String>,
     },
+    #[command(about = "Create a proposal on a feature gate multisig")]
+    #[command(
+        long_about = "Creates a new proposal on the feature gate multisig: activate or revoke the feature (vault transaction), or rekey the multisig (config transaction). Runs the feature-state pre-flight check and confirms before sending."
+    )]
+    Propose {
+        #[command(flatten)]
+        args: ProposalActionArgs,
+    },
+    #[command(about = "Approve a proposal on a feature gate multisig")]
+    Approve {
+        #[command(flatten)]
+        args: ProposalActionArgs,
+        #[arg(
+            long,
+            help = "Proposal index to approve (see `show` for live proposals)"
+        )]
+        index: u64,
+    },
+    #[command(about = "Reject a proposal on a feature gate multisig")]
+    Reject {
+        #[command(flatten)]
+        args: ProposalActionArgs,
+        #[arg(
+            long,
+            help = "Proposal index to reject (see `show` for live proposals)"
+        )]
+        index: u64,
+    },
+    #[command(about = "Execute an approved proposal on a feature gate multisig")]
+    Execute {
+        #[command(flatten)]
+        args: ProposalActionArgs,
+        #[arg(
+            long,
+            help = "Proposal index to execute (see `show` for live proposals)"
+        )]
+        index: u64,
+    },
     #[command(about = "Start interactive mode (default when no command is specified)")]
     #[command(
         long_about = "Launches the interactive mode which provides a guided experience for creating multisig wallets. This is the default mode when no command is specified."
@@ -110,6 +149,51 @@ The contributor key receives Initiate-only permissions, while additional members
 • Configuration file location"
     )]
     Config,
+}
+
+/// Arguments shared by the proposal subcommands (propose/approve/reject/execute).
+#[derive(Args)]
+struct ProposalActionArgs {
+    #[arg(long, help = "The feature gate multisig address")]
+    multisig: String,
+    #[arg(long, value_enum, help = "What the proposal does")]
+    kind: KindArg,
+    #[arg(
+        long,
+        help = "Voting key: your EOA or parent multisig (defaults to the saved config value)"
+    )]
+    voting_key: Option<String>,
+    #[arg(
+        short = 'k',
+        long,
+        help = "Fee payer keypair path (defaults to the saved config value)"
+    )]
+    keypair: Option<String>,
+    #[arg(
+        long,
+        help = "Non-interactive: resolve each confirmation to its default answer"
+    )]
+    yes: bool,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum KindArg {
+    /// Activate the feature gate
+    Activate,
+    /// Revoke a pending feature gate activation
+    Revoke,
+    /// Rekey the multisig (permanently disables voting)
+    Rekey,
+}
+
+impl From<KindArg> for TransactionKind {
+    fn from(kind: KindArg) -> Self {
+        match kind {
+            KindArg::Activate => TransactionKind::Activate,
+            KindArg::Revoke => TransactionKind::Revoke,
+            KindArg::Rekey => TransactionKind::Rekey,
+        }
+    }
 }
 
 fn main() {
@@ -164,7 +248,39 @@ fn handle_command(command: Commands) -> Result<()> {
         }
         Commands::Show { address } => show_command(&config, address),
         Commands::Verify { address } => verify_command(&config, address),
+        Commands::Propose { args } => run_proposal(&config, ProposalCommand::Propose, args, None),
+        Commands::Approve { args, index } => {
+            run_proposal(&config, ProposalCommand::Approve, args, Some(index))
+        }
+        Commands::Reject { args, index } => {
+            run_proposal(&config, ProposalCommand::Reject, args, Some(index))
+        }
+        Commands::Execute { args, index } => {
+            run_proposal(&config, ProposalCommand::Execute, args, Some(index))
+        }
         Commands::Interactive => interactive_mode(),
         Commands::Config => config_command(&config),
     }
+}
+
+fn run_proposal(
+    config: &crate::utils::Config,
+    command: ProposalCommand,
+    args: ProposalActionArgs,
+    index: Option<u64>,
+) -> Result<()> {
+    if args.yes {
+        std::env::set_var(crate::utils::ASSUME_YES_ENV, "1");
+    }
+    proposal_command(
+        config,
+        command,
+        ProposalCommandArgs {
+            multisig: args.multisig,
+            kind: args.kind.into(),
+            voting_key: args.voting_key,
+            keypair: args.keypair,
+            index,
+        },
+    )
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,6 +33,10 @@ pub struct Config {
     pub networks: Vec<String>,
     #[serde(default)]
     pub fee_payer_path: Option<String>,
+    /// Default voting key (EOA or parent multisig) for proposal actions. A signer's
+    /// identity is stable across the many feature gate multisigs they act on.
+    #[serde(default)]
+    pub voting_key: Option<String>,
 }
 
 impl Default for Config {
@@ -42,6 +46,7 @@ impl Default for Config {
             members: Vec::new(),
             networks: vec![DEFAULT_DEVNET_URL.to_string()],
             fee_payer_path: None,
+            voting_key: None,
         }
     }
 }
@@ -60,6 +65,16 @@ pub struct DeploymentResult {
 /// and picks defaults non-interactively.
 pub fn is_e2e_test_mode() -> bool {
     std::env::var("E2E_TEST_MODE").is_ok()
+}
+
+/// Env var set by the `--yes` CLI flag. Confirmations resolve to their default
+/// answer instead of prompting, so routine "send now?" prompts proceed while
+/// safety prompts that default to "no" (e.g. pre-flight warnings) still abort.
+pub const ASSUME_YES_ENV: &str = "FEATURE_GATE_MULTISIG_ASSUME_YES";
+
+/// True when `--yes` was passed: take each confirmation's default answer.
+pub fn is_assume_yes() -> bool {
+    std::env::var(ASSUME_YES_ENV).is_ok()
 }
 
 /// Load a signer from a CLI-style path: a keypair file or `usb://ledger`.
@@ -579,6 +594,11 @@ pub fn choose_network_from_config(config: &Config) -> Result<String> {
 
     if available_networks.is_empty() {
         return Err(eyre::eyre!("No networks available"));
+    }
+
+    // Nothing to choose: a single configured network is used as-is.
+    if available_networks.len() == 1 {
+        return Ok(available_networks[0].to_string());
     }
 
     // Non-interactive mode for E2E tests

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -24,6 +24,9 @@ use solana_signer::Signer;
 use once_cell::sync::OnceCell;
 
 use feature_gate_multisig_tool::commands::create::create_command_with_deployments;
+use feature_gate_multisig_tool::commands::proposal::{
+    proposal_command, ProposalCommand, ProposalCommandArgs,
+};
 use feature_gate_multisig_tool::commands::transaction_generation::{
     approve_common_feature_gate_proposal, create_feature_gate_proposal,
     execute_common_feature_gate_proposal, reject_common_feature_gate_proposal,
@@ -173,6 +176,7 @@ fn build_fixture() -> Fixture {
         threshold: 3,
         members,
         fee_payer_path: Some(fee_payer_path.to_string_lossy().to_string()),
+        voting_key: None,
     };
 
     let deployments = create_command_with_deployments(
@@ -220,6 +224,62 @@ fn wait_for_account(client: &RpcClient, address: &Pubkey) {
         std::thread::sleep(std::time::Duration::from_millis(500));
     }
     panic!("surfpool did not load account {address} within 30s");
+}
+
+/// Create three funded EOA members (keypair files under the temp dir with a
+/// unique `prefix`) and deploy a fresh feature gate multisig with them via the
+/// real CLI create flow, which pre-creates the activation proposal at index 1.
+/// Returns (config, multisig, vault, eoa pubkeys, eoa keypair paths).
+fn setup_eoa_multisig(
+    client: &RpcClient,
+    prefix: &str,
+    threshold: u16,
+) -> (Config, Pubkey, Pubkey, Vec<Pubkey>, Vec<String>) {
+    let temp_dir: PathBuf = std::env::temp_dir();
+    let mut eoa_keypaths = Vec::new();
+    let mut eoa_pubkeys = Vec::new();
+    for i in 0..3 {
+        let eoa = Keypair::new();
+        let sig = client
+            .request_airdrop(&eoa.pubkey(), 10_000_000_000)
+            .expect("request airdrop for eoa");
+        client
+            .confirm_transaction(&sig)
+            .expect("confirm airdrop for eoa");
+
+        let keypair_path = temp_dir.join(format!("{}_{}.json", prefix, i));
+        std::fs::write(
+            &keypair_path,
+            serde_json::to_string(&eoa.to_bytes().to_vec()).unwrap(),
+        )
+        .expect("write eoa keypair");
+
+        eoa_pubkeys.push(eoa.pubkey());
+        eoa_keypaths.push(keypair_path.to_string_lossy().to_string());
+    }
+
+    let mut config = Config {
+        networks: vec![rpc_url()],
+        threshold,
+        members: eoa_pubkeys.iter().map(|p| p.to_string()).collect(),
+        fee_payer_path: Some(eoa_keypaths[0].clone()),
+        voting_key: None,
+    };
+
+    let deployments = create_command_with_deployments(
+        &mut config,
+        Some(threshold),
+        Some(eoa_keypaths[0].clone()),
+    )
+    .expect("create feature gate via CLI");
+    let deployment = deployments.first().expect("deployment should exist");
+    (
+        config,
+        deployment.multisig_address,
+        deployment.vault_address,
+        eoa_pubkeys,
+        eoa_keypaths,
+    )
 }
 
 #[test]
@@ -871,51 +931,8 @@ fn rpc_e2e_7_eoa_activation_flow() {
     init_test_env();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
-    let temp_dir: PathBuf = std::env::temp_dir();
-
-    // Create 3 EOA members for a new child multisig
-    let mut eoa_keypaths = Vec::new();
-    let mut eoa_pubkeys = Vec::new();
-
-    for i in 0..3 {
-        let eoa = Keypair::new();
-        let sig = client
-            .request_airdrop(&eoa.pubkey(), 10_000_000_000)
-            .expect("request airdrop for eoa");
-        client
-            .confirm_transaction(&sig)
-            .expect("confirm airdrop for eoa");
-
-        let keypair_path = temp_dir.join(format!("eoa_test7_{}.json", i));
-        let keypair_bytes: Vec<u8> = eoa.to_bytes().to_vec();
-        std::fs::write(
-            &keypair_path,
-            serde_json::to_string(&keypair_bytes).unwrap(),
-        )
-        .expect("write eoa keypair");
-
-        eoa_pubkeys.push(eoa.pubkey());
-        eoa_keypaths.push(keypair_path.to_string_lossy().to_string());
-    }
-
-    // Use create_command_with_deployments like the real CLI - this creates multisig + initial activation proposal
-    let mut config = Config {
-        networks: vec![rpc_url()],
-        threshold: 2,
-        members: eoa_pubkeys.iter().map(|p| p.to_string()).collect(),
-        fee_payer_path: Some(eoa_keypaths[0].clone()),
-    };
-
-    let deployments = create_command_with_deployments(
-        &mut config,
-        Some(2), // threshold
-        Some(eoa_keypaths[0].clone()),
-    )
-    .expect("create feature gate via CLI");
-
-    let deployment = deployments.first().expect("deployment should exist");
-    let child_multisig = deployment.multisig_address;
-    let child_vault = deployment.vault_address;
+    let (config, child_multisig, child_vault, eoa_pubkeys, eoa_keypaths) =
+        setup_eoa_multisig(&client, "eoa_test7", 2);
 
     println!(
         "✅ Created EOA-only child multisig via CLI: {}",
@@ -1020,51 +1037,8 @@ fn rpc_e2e_8_eoa_revocation_flow() {
     init_test_env();
 
     let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
-    let temp_dir: PathBuf = std::env::temp_dir();
-
-    // Create 3 EOA members
-    let mut eoa_keypaths = Vec::new();
-    let mut eoa_pubkeys = Vec::new();
-
-    for i in 0..3 {
-        let eoa = Keypair::new();
-        let sig = client
-            .request_airdrop(&eoa.pubkey(), 10_000_000_000)
-            .expect("request airdrop for eoa");
-        client
-            .confirm_transaction(&sig)
-            .expect("confirm airdrop for eoa");
-
-        let keypair_path = temp_dir.join(format!("eoa_test8_{}.json", i));
-        let keypair_bytes: Vec<u8> = eoa.to_bytes().to_vec();
-        std::fs::write(
-            &keypair_path,
-            serde_json::to_string(&keypair_bytes).unwrap(),
-        )
-        .expect("write eoa keypair");
-
-        eoa_pubkeys.push(eoa.pubkey());
-        eoa_keypaths.push(keypair_path.to_string_lossy().to_string());
-    }
-
-    // Use create_command_with_deployments like the real CLI - this creates multisig + initial activation proposal
-    let mut config = Config {
-        networks: vec![rpc_url()],
-        threshold: 2,
-        members: eoa_pubkeys.iter().map(|p| p.to_string()).collect(),
-        fee_payer_path: Some(eoa_keypaths[0].clone()),
-    };
-
-    let deployments = create_command_with_deployments(
-        &mut config,
-        Some(2), // threshold
-        Some(eoa_keypaths[0].clone()),
-    )
-    .expect("create feature gate via CLI");
-
-    let deployment = deployments.first().expect("deployment should exist");
-    let child_multisig = deployment.multisig_address;
-    let child_vault = deployment.vault_address;
+    let (config, child_multisig, child_vault, eoa_pubkeys, eoa_keypaths) =
+        setup_eoa_multisig(&client, "eoa_test8", 2);
 
     println!(
         "✅ Created EOA-only child multisig via CLI: {}",
@@ -1252,39 +1226,8 @@ fn rpc_e2e_9_verify_checks() {
 
     // Build an isolated EOA multisig so the feature-state transition is
     // deterministic and independent of the other tests.
-    let temp_dir: PathBuf = std::env::temp_dir();
-    let mut eoa_keypaths = Vec::new();
-    let mut eoa_pubkeys = Vec::new();
-    for i in 0..3 {
-        let eoa = Keypair::new();
-        let sig = client
-            .request_airdrop(&eoa.pubkey(), 10_000_000_000)
-            .expect("request airdrop for eoa");
-        client.confirm_transaction(&sig).expect("confirm airdrop");
-
-        let keypair_path = temp_dir.join(format!("eoa_test9_{}.json", i));
-        std::fs::write(
-            &keypair_path,
-            serde_json::to_string(&eoa.to_bytes().to_vec()).unwrap(),
-        )
-        .expect("write eoa keypair");
-
-        eoa_pubkeys.push(eoa.pubkey());
-        eoa_keypaths.push(keypair_path.to_string_lossy().to_string());
-    }
-
-    let mut config = Config {
-        networks: vec![rpc_url()],
-        threshold: 2,
-        members: eoa_pubkeys.iter().map(|p| p.to_string()).collect(),
-        fee_payer_path: Some(eoa_keypaths[0].clone()),
-    };
-
-    let deployments =
-        create_command_with_deployments(&mut config, Some(2), Some(eoa_keypaths[0].clone()))
-            .expect("create feature gate via CLI");
-    let deployment = deployments.first().expect("deployment should exist");
-    let child_multisig = deployment.multisig_address;
+    let (config, child_multisig, _vault, eoa_pubkeys, eoa_keypaths) =
+        setup_eoa_multisig(&client, "eoa_test9", 2);
 
     // Before execution the feature account (vault 0) is unallocated -> Fresh.
     let before = verify_feature_gate(&client, &child_multisig).expect("verify feature (fresh)");
@@ -1361,4 +1304,80 @@ fn rpc_e2e_9_verify_checks() {
     verify_command(&config, Some(child_multisig.to_string()))
         .expect("verify command should run cleanly against the activated multisig");
     println!("✅ verify command ran end to end");
+}
+
+/// Test 10: the non-interactive proposal subcommands drive a full feature gate
+/// lifecycle end to end: approve + execute the pre-created activation, then
+/// propose, approve, and execute a revocation.
+#[test]
+#[ignore = "requires a running surfpool validator; run via make test-surfpool"]
+fn rpc_e2e_10_proposal_subcommands() {
+    init_test_env();
+
+    let client = RpcClient::new_with_commitment(rpc_url(), CommitmentConfig::confirmed());
+    wait_for_account(&client, &SQUADS_MULTISIG_PROGRAM_ID);
+
+    let (config, multisig, _vault, eoa_pubkeys, eoa_keypaths) =
+        setup_eoa_multisig(&client, "eoa_test10", 2);
+
+    let args = |voter: usize, kind: TransactionKind, index: Option<u64>| ProposalCommandArgs {
+        multisig: multisig.to_string(),
+        kind,
+        voting_key: Some(eoa_pubkeys[voter].to_string()),
+        keypair: Some(eoa_keypaths[voter].clone()),
+        index,
+    };
+
+    // The create flow pre-creates the activation proposal at index 1.
+    for voter in 0..2 {
+        proposal_command(
+            &config,
+            ProposalCommand::Approve,
+            args(voter, TransactionKind::Activate, Some(1)),
+        )
+        .expect("approve activation via subcommand");
+    }
+    proposal_command(
+        &config,
+        ProposalCommand::Execute,
+        args(1, TransactionKind::Activate, Some(1)),
+    )
+    .expect("execute activation via subcommand");
+
+    let activated = verify_feature_gate(&client, &multisig).expect("verify feature (pending)");
+    assert_eq!(
+        activated.status,
+        FeatureGateStatus::Pending,
+        "feature should be Pending after subcommand-driven activation"
+    );
+
+    // Revoke: propose (lands at index 2), approve to threshold, execute.
+    proposal_command(
+        &config,
+        ProposalCommand::Propose,
+        args(0, TransactionKind::Revoke, None),
+    )
+    .expect("propose revoke via subcommand");
+    for voter in 0..2 {
+        proposal_command(
+            &config,
+            ProposalCommand::Approve,
+            args(voter, TransactionKind::Revoke, Some(2)),
+        )
+        .expect("approve revoke via subcommand");
+    }
+    proposal_command(
+        &config,
+        ProposalCommand::Execute,
+        args(1, TransactionKind::Revoke, Some(2)),
+    )
+    .expect("execute revoke via subcommand");
+
+    let reverted = verify_feature_gate(&client, &multisig).expect("verify feature (fresh)");
+    assert_eq!(
+        reverted.status,
+        FeatureGateStatus::Fresh,
+        "feature should be Fresh again after the subcommand-driven revoke"
+    );
+    println!("✅ proposal subcommands drove the full lifecycle end to end");
 }


### PR DESCRIPTION
### Details
- New `commands/proposal.rs` resolves arguments and routes by kind: rekey goes
  to the config transaction paths, activate/revoke to the vault paths, exactly
  mirroring the interactive dispatch
- `--voting-key` falls back to a new `voting_key` config default. A signer's
  identity stays the same across the many feature gate multisigs they act on,
  so entering it once and saving it removes a prompt from every future action.
  Fee payer already worked this way.
- `--yes` resolves each confirmation to its default answer instead of blanket
  approving: routine "send now?" prompts proceed, but the pre flight safety
  prompt (defaults to no) still aborts. You cannot `--yes` through a "feature
  is already activated" warning.
- Single network configs skip the network picker prompt
