### PR TITLE
Proposal picker

### DIFF
--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -19,6 +19,9 @@ use solana_rpc_client::rpc_client::RpcClient;
 
 pub fn interactive_mode() -> Result<()> {
     let mut config = load_config()?;
+    // Session memory: the multisig acted on last, pre-filled on the next pass.
+    // Useful when driving the same feature gate across several networks.
+    let mut last_multisig: Option<String> = None;
 
     loop {
         let options = vec![
@@ -40,7 +43,9 @@ pub fn interactive_mode() -> Result<()> {
         let result = match choice {
             "Create new feature gate multisig" => prompt_for_fee_payer_path(&config)
                 .and_then(|path| create_command(&mut config, None, Some(path))),
-            "Proposal Actions (Approve/Reject/Execute)" => handle_proposal_action(&config),
+            "Proposal Actions (Approve/Reject/Execute)" => {
+                handle_proposal_action(&config, &mut last_multisig)
+            }
             "Show feature gate multisig details" => Text::new("Enter the main multisig address:")
                 .prompt()
                 .map_err(eyre::Report::from)
@@ -75,10 +80,14 @@ fn is_prompt_cancellation(error: &eyre::Report) -> bool {
     )
 }
 
-fn handle_proposal_action(config: &Config) -> Result<()> {
+fn handle_proposal_action(config: &Config, last_multisig: &mut Option<String>) -> Result<()> {
     println!("In the current setup, only the fee payer keypair is used for transactions, hence for EOA voting fee payer = voting account. For multisig setup, the fee payer needs to be a member of the parent multisig.\n");
 
-    let multisig = prompt_for_pubkey("Enter the feature gate multisig address:")?;
+    let multisig = prompt_for_pubkey_with_default(
+        "Enter the feature gate multisig address:",
+        last_multisig.as_deref(),
+    )?;
+    *last_multisig = Some(multisig.to_string());
     let feature_gate_id = get_vault_pda(&multisig, 0).0;
 
     // Pick the network once up front: the proposal picker queries it, and the

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -30,35 +30,49 @@ pub fn interactive_mode() -> Result<()> {
             "Exit",
         ];
 
-        let choice: &str = Select::new("What would you like to do?", options).prompt()?;
+        let choice: &str = match Select::new("What would you like to do?", options).prompt() {
+            Ok(choice) => choice,
+            // Esc at the top level means quit.
+            Err(inquire::InquireError::OperationCanceled) => break,
+            Err(e) => return Err(e.into()),
+        };
 
-        match choice {
-            "Create new feature gate multisig" => {
-                let feepayer_path = prompt_for_fee_payer_path(&config)?;
-                create_command(&mut config, None, Some(feepayer_path))?;
-            }
-            "Proposal Actions (Approve/Reject/Execute)" => {
-                handle_proposal_action(&config)?;
-            }
-            "Show feature gate multisig details" => {
-                let address = Text::new("Enter the main multisig address:").prompt()?;
-                show_command(&config, Some(address))?;
-            }
-            "Verify feature gate multisig" => {
-                let address = Text::new("Enter the feature gate multisig address:").prompt()?;
-                verify_command(&config, Some(address))?;
-            }
-            "Show configuration" => {
-                config_command(&config)?;
-            }
+        let result = match choice {
+            "Create new feature gate multisig" => prompt_for_fee_payer_path(&config)
+                .and_then(|path| create_command(&mut config, None, Some(path))),
+            "Proposal Actions (Approve/Reject/Execute)" => handle_proposal_action(&config),
+            "Show feature gate multisig details" => Text::new("Enter the main multisig address:")
+                .prompt()
+                .map_err(eyre::Report::from)
+                .and_then(|address| show_command(&config, Some(address))),
+            "Verify feature gate multisig" => Text::new("Enter the feature gate multisig address:")
+                .prompt()
+                .map_err(eyre::Report::from)
+                .and_then(|address| verify_command(&config, Some(address))),
+            "Show configuration" => config_command(&config),
             "Exit" => break,
             _ => unreachable!(),
+        };
+
+        // Esc inside an action cancels back to the menu; real errors still exit.
+        match result {
+            Ok(()) => {}
+            Err(e) if is_prompt_cancellation(&e) => Output::info("Cancelled."),
+            Err(e) => return Err(e),
         }
 
         println!("\n");
     }
 
     Ok(())
+}
+
+/// True when the error is the user pressing Esc in an inquire prompt.
+fn is_prompt_cancellation(error: &eyre::Report) -> bool {
+    matches!(
+        error.downcast_ref::<inquire::InquireError>(),
+        Some(inquire::InquireError::OperationCanceled)
+    )
 }
 
 fn handle_proposal_action(config: &Config) -> Result<()> {

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -69,13 +69,13 @@ fn handle_proposal_action(config: &Config) -> Result<()> {
 
     // Pick the network once up front: the proposal picker queries it, and the
     // single-network config makes the downstream flows skip their own prompt.
+    // The original `config` stays around for prompts that persist defaults.
     let rpc_url = choose_network_from_config(config)?;
     let rpc_client = create_rpc_client(&rpc_url);
-    let config = Config {
+    let network_config = Config {
         networks: vec![rpc_url],
         ..config.clone()
     };
-    let config = &config;
 
     let action_options = vec!["Create", "Approve", "Reject", "Execute", "Cancel"];
     let action_choice: &str = Select::new("Select action:", action_options).prompt()?;
@@ -129,15 +129,19 @@ fn handle_proposal_action(config: &Config) -> Result<()> {
         (command, kind, Some(index))
     };
 
-    // Same entry point as the CLI subcommands: fee payer and voting key resolve
-    // from saved config defaults, prompting only when absent.
+    // Prompt with the saved default pre-filled (editable), and pass the key
+    // explicitly: interactive users always see which identity is voting.
+    let voting_key = prompt_for_voting_key(config)?;
+
+    // Same entry point as the CLI subcommands; the fee payer resolves from the
+    // saved config default, prompting only when absent.
     proposal_command(
-        config,
+        &network_config,
         command,
         ProposalCommandArgs {
             multisig: multisig.to_string(),
             kind,
-            voting_key: None,
+            voting_key: Some(voting_key.to_string()),
             keypair: None,
             index,
         },

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -300,8 +300,8 @@ fn is_actionable(
     }
 }
 
-/// List the multisig's proposals that `action` can still act on — with what
-/// they do, their status, and vote counts — and let the user pick one instead
+/// List the multisig's proposals that `action` can still act on - with what
+/// they do, their status, and vote counts - and let the user pick one instead
 /// of typing an index from memory. Executed, rejected, cancelled, and stale
 /// proposals are skipped (with a note). Falls back to manual entry when
 /// nothing is listable or the user prefers. Returns the chosen index and its
@@ -344,7 +344,7 @@ fn prompt_for_proposal_index(
                 }
                 entries.push((index, kind));
                 options.push(format!(
-                    "#{index} — {} — {} — {} approval(s), {} rejection(s)",
+                    "#{index} - {} - {} - {} approval(s), {} rejection(s)",
                     kind.label(),
                     proposal_status_label(&proposal.status),
                     proposal.approved.len(),

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -1,13 +1,21 @@
 use crate::commands::{
-    approve_common_config_change, approve_common_feature_gate_proposal, config_command,
-    create_command, create_feature_gate_proposal, execute_common_config_change,
-    execute_common_feature_gate_proposal, reject_common_feature_gate_proposal,
-    rekey_multisig_feature_gate, show_command, verify_command, TransactionKind,
+    config_command, create_command, proposal_command, show_command, verify_command,
+    ProposalCommand, ProposalCommandArgs, TransactionKind,
 };
-use crate::squads::get_vault_pda;
+use crate::feature_gate_program::FEATURE_GATE_PROGRAM_ID;
+use crate::output::Output;
+use crate::provision::{create_rpc_client, fetch_squads_multisig};
+use crate::squads::{
+    deserialize_squads_account, get_proposal_pda, get_transaction_pda, get_vault_pda,
+    ConfigTransaction, Proposal, ProposalStatus, VaultTransaction,
+    CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR, PROPOSAL_ACCOUNT_DISCRIMINATOR,
+    SQUADS_MULTISIG_PROGRAM_ID, VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+};
 use crate::utils::*;
 use eyre::Result;
 use inquire::{Confirm, Select, Text};
+use solana_pubkey::Pubkey;
+use solana_rpc_client::rpc_client::RpcClient;
 
 pub fn interactive_mode() -> Result<()> {
     let mut config = load_config()?;
@@ -56,66 +64,61 @@ pub fn interactive_mode() -> Result<()> {
 fn handle_proposal_action(config: &Config) -> Result<()> {
     println!("In the current setup, only the fee payer keypair is used for transactions, hence for EOA voting fee payer = voting account. For multisig setup, the fee payer needs to be a member of the parent multisig.\n");
 
-    // Collect common inputs
-    let feature_gate_multisig_address =
-        prompt_for_pubkey("Enter the feature gate multisig address:")?;
-    let feature_gate_id = get_vault_pda(&feature_gate_multisig_address, 0).0;
-    let fee_payer_path = prompt_for_fee_payer_path(config)?;
-    let voting_key =
-        prompt_for_pubkey("Enter the voting key: (Can be either EOA or parent multisig)")?;
+    let multisig = prompt_for_pubkey("Enter the feature gate multisig address:")?;
+    let feature_gate_id = get_vault_pda(&multisig, 0).0;
 
-    // Select transaction type
-    let type_options = vec![
-        "Activate Feature Gate",
-        "Revoke Feature Gate",
-        "Rekey Multisig (this will brick the multisig)",
-        "Cancel",
-    ];
-    let type_choice: &str = Select::new("Select transaction type:", type_options).prompt()?;
-
-    if type_choice == "Cancel" {
-        return Ok(());
-    }
-
-    let kind = match type_choice {
-        "Activate Feature Gate" => TransactionKind::Activate,
-        "Revoke Feature Gate" => TransactionKind::Revoke,
-        "Rekey Multisig (this will brick the multisig)" => TransactionKind::Rekey,
-        _ => unreachable!(),
+    // Pick the network once up front: the proposal picker queries it, and the
+    // single-network config makes the downstream flows skip their own prompt.
+    let rpc_url = choose_network_from_config(config)?;
+    let rpc_client = create_rpc_client(&rpc_url);
+    let config = Config {
+        networks: vec![rpc_url],
+        ..config.clone()
     };
+    let config = &config;
 
-    // Select action - Rekey now supports Reject as well
     let action_options = vec!["Create", "Approve", "Reject", "Execute", "Cancel"];
     let action_choice: &str = Select::new("Select action:", action_options).prompt()?;
-
     if action_choice == "Cancel" {
         return Ok(());
     }
 
-    if kind != TransactionKind::Rekey {
-        // Feature Gate operations (Activate/Revoke)
-        if action_choice == "Create" {
-            // For Create, we don't need proposal index - we're creating a new one
-            return create_feature_gate_proposal(
-                config,
-                feature_gate_multisig_address,
-                voting_key,
-                fee_payer_path,
-                kind,
-            );
-        }
+    // Create picks a kind (nothing exists to infer from); the other actions pick
+    // a live proposal, and its kind comes from the on-chain transaction shape.
+    let (command, kind, index) = if action_choice == "Create" {
+        let Some(kind) = prompt_for_transaction_kind()? else {
+            return Ok(());
+        };
+        (ProposalCommand::Propose, kind, None)
+    } else {
+        let command = match action_choice {
+            "Approve" => ProposalCommand::Approve,
+            "Reject" => ProposalCommand::Reject,
+            "Execute" => ProposalCommand::Execute,
+            _ => unreachable!(),
+        };
 
-        let proposal_index_str = Text::new("Enter the proposal index:").prompt()?;
-        let proposal_index: u64 = proposal_index_str
-            .parse()
-            .map_err(|_| eyre::eyre!("Invalid proposal index"))?;
+        let (index, proposal_kind) = prompt_for_proposal_index(&rpc_client, &multisig, command)?;
+        let kind = match proposal_kind.transaction_kind() {
+            Some(kind) => kind,
+            // Not a shape this tool creates; the user has to say how to route it.
+            None => {
+                Output::warning(
+                    "Could not classify this proposal from its on-chain transaction; select its type:",
+                );
+                let Some(kind) = prompt_for_transaction_kind()? else {
+                    return Ok(());
+                };
+                kind
+            }
+        };
 
         let confirmed = Confirm::new(&format!(
-            "You're {}ing the {} of feature gate {} at proposal index {}. Continue?",
+            "You're about to {} proposal #{} ({}) on feature gate {}. Continue?",
             action_choice.to_lowercase(),
-            type_choice.to_lowercase(),
+            index,
+            proposal_kind.label(),
             feature_gate_id,
-            proposal_index
         ))
         .with_default(true)
         .prompt()?;
@@ -123,118 +126,302 @@ fn handle_proposal_action(config: &Config) -> Result<()> {
             return Ok(());
         }
 
-        match action_choice {
-            "Approve" => {
-                approve_common_feature_gate_proposal(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                    kind,
-                )?;
-            }
-            "Reject" => {
-                reject_common_feature_gate_proposal(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                    kind,
-                )?;
-            }
-            "Execute" => {
-                execute_common_feature_gate_proposal(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                    kind,
-                )?;
-            }
-            _ => unreachable!(),
-        }
-    } else {
-        // Rekey operation
-        if action_choice == "Create" {
-            // Create does not require a proposal index
-            return rekey_multisig_feature_gate(
-                config,
-                feature_gate_multisig_address,
-                voting_key,
-                fee_payer_path,
-            );
-        }
+        (command, kind, Some(index))
+    };
 
-        let proposal_index_str = Text::new("Enter the proposal index:").prompt()?;
-        let proposal_index: u64 = proposal_index_str
-            .parse()
-            .map_err(|_| eyre::eyre!("Invalid proposal index"))?;
+    // Same entry point as the CLI subcommands: fee payer and voting key resolve
+    // from saved config defaults, prompting only when absent.
+    proposal_command(
+        config,
+        command,
+        ProposalCommandArgs {
+            multisig: multisig.to_string(),
+            kind,
+            voting_key: None,
+            keypair: None,
+            index,
+        },
+    )
+}
 
-        match action_choice {
-            "Approve" => {
-                let confirmed = Confirm::new(&format!(
-                    "You're approving the rekey proposal at index {}. Continue?",
-                    proposal_index
-                ))
-                .with_default(true)
-                .prompt()?;
-                if !confirmed {
-                    return Ok(());
-                }
+/// Ask which kind of transaction to work with. Returns None on cancel.
+fn prompt_for_transaction_kind() -> Result<Option<TransactionKind>> {
+    let options = vec![
+        "Activate Feature Gate",
+        "Revoke Feature Gate",
+        "Rekey Multisig (this will brick the multisig)",
+        "Cancel",
+    ];
+    let choice: &str = Select::new("Select transaction type:", options).prompt()?;
+    Ok(match choice {
+        "Activate Feature Gate" => Some(TransactionKind::Activate),
+        "Revoke Feature Gate" => Some(TransactionKind::Revoke),
+        "Rekey Multisig (this will brick the multisig)" => Some(TransactionKind::Rekey),
+        _ => None,
+    })
+}
 
-                approve_common_config_change(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                )?;
-            }
-            "Reject" => {
-                let confirmed = Confirm::new(&format!(
-                    "You're rejecting the rekey proposal at index {}. Continue?",
-                    proposal_index
-                ))
-                .with_default(true)
-                .prompt()?;
-                if !confirmed {
-                    return Ok(());
-                }
+/// What a proposal's companion transaction does, classified from its on-chain
+/// shape. The tool only creates three forms: activate (System-program
+/// allocate+assign), revoke (an instruction to the Feature Gate program), and
+/// rekey (a config transaction).
+#[derive(Clone, Copy)]
+enum ProposalKind {
+    Activate,
+    Revoke,
+    Rekey,
+    ChildAction,
+    Other,
+    Unknown,
+}
 
-                reject_common_feature_gate_proposal(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                    TransactionKind::Rekey,
-                )?;
-            }
-            "Execute" => {
-                let confirmed = Confirm::new(&format!(
-                    "You're executing the rekey proposal at index {}. Continue?",
-                    proposal_index
-                ))
-                .with_default(true)
-                .prompt()?;
-                if !confirmed {
-                    return Ok(());
-                }
-
-                execute_common_config_change(
-                    config,
-                    feature_gate_multisig_address,
-                    voting_key,
-                    fee_payer_path,
-                    proposal_index,
-                )?;
-            }
-            _ => unreachable!(),
+impl ProposalKind {
+    fn label(self) -> &'static str {
+        match self {
+            ProposalKind::Activate => "Activate feature gate",
+            ProposalKind::Revoke => "Revoke feature gate",
+            ProposalKind::Rekey => "Rekey (config change)",
+            ProposalKind::ChildAction => "Child multisig action",
+            ProposalKind::Other => "Vault transaction",
+            ProposalKind::Unknown => "Unknown",
         }
     }
 
-    Ok(())
+    fn transaction_kind(self) -> Option<TransactionKind> {
+        match self {
+            ProposalKind::Activate => Some(TransactionKind::Activate),
+            ProposalKind::Revoke => Some(TransactionKind::Revoke),
+            ProposalKind::Rekey => Some(TransactionKind::Rekey),
+            ProposalKind::ChildAction | ProposalKind::Other | ProposalKind::Unknown => None,
+        }
+    }
+}
+
+fn describe_transaction(rpc_client: &RpcClient, multisig: &Pubkey, index: u64) -> ProposalKind {
+    let (transaction_pda, _) = get_transaction_pda(multisig, index);
+    let Ok(account) = rpc_client.get_account(&transaction_pda) else {
+        return ProposalKind::Unknown;
+    };
+
+    if deserialize_squads_account::<ConfigTransaction>(
+        &account.data,
+        CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+        "config transaction",
+    )
+    .is_ok()
+    {
+        return ProposalKind::Rekey;
+    }
+
+    let Ok(vault_tx) = deserialize_squads_account::<VaultTransaction>(
+        &account.data,
+        VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+        "vault transaction",
+    ) else {
+        return ProposalKind::Unknown;
+    };
+
+    let programs: Vec<&Pubkey> = vault_tx
+        .message
+        .instructions
+        .iter()
+        .filter_map(|ix| {
+            vault_tx
+                .message
+                .account_keys
+                .get(ix.program_id_index as usize)
+        })
+        .collect();
+
+    if programs.iter().any(|p| **p == FEATURE_GATE_PROGRAM_ID) {
+        ProposalKind::Revoke
+    } else if programs
+        .iter()
+        .all(|p| **p == solana_system_interface::program::ID)
+    {
+        ProposalKind::Activate
+    } else if programs.iter().any(|p| **p == SQUADS_MULTISIG_PROGRAM_ID) {
+        ProposalKind::ChildAction
+    } else {
+        ProposalKind::Other
+    }
+}
+
+fn proposal_status_label(status: &ProposalStatus) -> &'static str {
+    match status {
+        ProposalStatus::Draft { .. } => "Draft",
+        ProposalStatus::Active { .. } => "Active",
+        ProposalStatus::Rejected { .. } => "Rejected",
+        ProposalStatus::Approved { .. } => "Approved",
+        ProposalStatus::Executing => "Executing",
+        ProposalStatus::Executed { .. } => "Executed",
+        ProposalStatus::Cancelled { .. } => "Cancelled",
+    }
+}
+
+/// Whether `action` can still be performed on a proposal, given its status and
+/// staleness. Voting (approve/reject) requires an Active proposal that is not
+/// stale. Execution requires an Approved proposal; a stale but approved vault
+/// transaction can still execute, while a stale config transaction cannot.
+fn is_actionable(
+    action: ProposalCommand,
+    status: &ProposalStatus,
+    kind: ProposalKind,
+    index: u64,
+    stale_index: u64,
+) -> bool {
+    match action {
+        ProposalCommand::Approve | ProposalCommand::Reject => {
+            matches!(status, ProposalStatus::Active { .. }) && index > stale_index
+        }
+        ProposalCommand::Execute => {
+            matches!(status, ProposalStatus::Approved { .. })
+                && (index > stale_index || !matches!(kind, ProposalKind::Rekey))
+        }
+        ProposalCommand::Propose => true,
+    }
+}
+
+/// List the multisig's proposals that `action` can still act on — with what
+/// they do, their status, and vote counts — and let the user pick one instead
+/// of typing an index from memory. Executed, rejected, cancelled, and stale
+/// proposals are skipped (with a note). Falls back to manual entry when
+/// nothing is listable or the user prefers. Returns the chosen index and its
+/// classified kind.
+fn prompt_for_proposal_index(
+    rpc_client: &RpcClient,
+    multisig: &Pubkey,
+    action: ProposalCommand,
+) -> Result<(u64, ProposalKind)> {
+    const MAX_LISTED: u64 = 10;
+
+    let mut entries: Vec<(u64, ProposalKind)> = Vec::new();
+    let mut options: Vec<String> = Vec::new();
+    let mut skipped = 0u64;
+    match fetch_squads_multisig(rpc_client, multisig, "multisig") {
+        Ok(ms) if ms.transaction_index > 0 => {
+            let first = ms.transaction_index.saturating_sub(MAX_LISTED - 1).max(1);
+            for index in first..=ms.transaction_index {
+                let (proposal_pda, _) = get_proposal_pda(multisig, index);
+                let Ok(account) = rpc_client.get_account(&proposal_pda) else {
+                    continue;
+                };
+                let Ok(proposal) = deserialize_squads_account::<Proposal>(
+                    &account.data,
+                    PROPOSAL_ACCOUNT_DISCRIMINATOR,
+                    "proposal",
+                ) else {
+                    continue;
+                };
+                let kind = describe_transaction(rpc_client, multisig, index);
+                if !is_actionable(
+                    action,
+                    &proposal.status,
+                    kind,
+                    index,
+                    ms.stale_transaction_index,
+                ) {
+                    skipped += 1;
+                    continue;
+                }
+                entries.push((index, kind));
+                options.push(format!(
+                    "#{index} — {} — {} — {} approval(s), {} rejection(s)",
+                    kind.label(),
+                    proposal_status_label(&proposal.status),
+                    proposal.approved.len(),
+                    proposal.rejected.len(),
+                ));
+            }
+        }
+        Ok(_) => {}
+        Err(e) => Output::warning(&format!("Could not list proposals: {e}")),
+    }
+
+    if skipped > 0 {
+        Output::info(&format!(
+            "Skipped {skipped} proposal(s) this action can no longer apply to (executed/rejected/cancelled/stale)."
+        ));
+    }
+
+    if !options.is_empty() {
+        options.push("Enter an index manually".to_string());
+        let selection = Select::new("Select a proposal:", options).raw_prompt()?;
+        if selection.index < entries.len() {
+            return Ok(entries[selection.index]);
+        }
+    } else {
+        Output::info("No proposals are currently actionable for this action.");
+    }
+
+    let index_str = Text::new("Enter the proposal index:").prompt()?;
+    let index: u64 = index_str
+        .parse()
+        .map_err(|_| eyre::eyre!("Invalid proposal index"))?;
+    Ok((index, describe_transaction(rpc_client, multisig, index)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn actionability_matrix() {
+        let active = ProposalStatus::Active { timestamp: 0 };
+        let approved = ProposalStatus::Approved { timestamp: 0 };
+        let executed = ProposalStatus::Executed { timestamp: 0 };
+        let rejected = ProposalStatus::Rejected { timestamp: 0 };
+        let cancelled = ProposalStatus::Cancelled { timestamp: 0 };
+
+        // Voting works only on Active, non-stale proposals.
+        for action in [ProposalCommand::Approve, ProposalCommand::Reject] {
+            assert!(is_actionable(action, &active, ProposalKind::Activate, 5, 2));
+            // stale (index <= stale_index)
+            assert!(!is_actionable(
+                action,
+                &active,
+                ProposalKind::Activate,
+                2,
+                2
+            ));
+            for status in [&approved, &executed, &rejected, &cancelled] {
+                assert!(!is_actionable(action, status, ProposalKind::Activate, 5, 2));
+            }
+        }
+
+        // Execute requires Approved; terminal states are out.
+        assert!(is_actionable(
+            ProposalCommand::Execute,
+            &approved,
+            ProposalKind::Activate,
+            5,
+            2
+        ));
+        for status in [&active, &executed, &rejected, &cancelled] {
+            assert!(!is_actionable(
+                ProposalCommand::Execute,
+                status,
+                ProposalKind::Activate,
+                5,
+                2
+            ));
+        }
+
+        // Stale exception: an approved vault transaction can still execute,
+        // but a stale config (rekey) transaction cannot.
+        assert!(is_actionable(
+            ProposalCommand::Execute,
+            &approved,
+            ProposalKind::Revoke,
+            2,
+            2
+        ));
+        assert!(!is_actionable(
+            ProposalCommand::Execute,
+            &approved,
+            ProposalKind::Rekey,
+            2,
+            2
+        ));
+    }
 }

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -115,7 +115,7 @@ fn build_config_actions_for_kind(
 
 /// Attempt to load an account as a Squads multisig. Returns Ok(None) if the account
 /// doesn't exist, isn't owned by the Squads program, or doesn't carry the Multisig
-/// account discriminator — this gates the EOA-vs-parent-multisig flow, so spoofable
+/// account discriminator - this gates the EOA-vs-parent-multisig flow, so spoofable
 /// lookalike data must not pass.
 fn load_multisig_if_any(
     rpc_client: &solana_rpc_client::rpc_client::RpcClient,
@@ -471,7 +471,7 @@ fn approve_and_maybe_execute_parent(
         output::Output::hint("Executor does not have Execute permission on the parent multisig.");
     } else {
         output::Output::hint(&format!(
-            "Parent approvals {}/{} — waiting for more confirmations before execution.",
+            "Parent approvals {}/{} - waiting for more confirmations before execution.",
             approved, threshold
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,11 @@ struct ProposalActionArgs {
     keypair: Option<String>,
     #[arg(
         long,
+        help = "Network to act on: a configured network name (devnet/testnet/mainnet) or an RPC URL. Prompts when omitted and several networks are configured"
+    )]
+    network: Option<String>,
+    #[arg(
+        long,
         help = "Non-interactive: resolve each confirmation to its default answer"
     )]
     yes: bool,
@@ -272,8 +277,14 @@ fn run_proposal(
     if args.yes {
         std::env::set_var(crate::utils::ASSUME_YES_ENV, "1");
     }
+    // --network narrows the config to one endpoint, so downstream flows use it
+    // without prompting.
+    let mut config = config.clone();
+    if let Some(network) = &args.network {
+        config.networks = vec![crate::utils::resolve_network_arg(&config, network)?];
+    }
     proposal_command(
-        config,
+        &config,
         command,
         ProposalCommandArgs {
             multisig: args.multisig,

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -64,7 +64,7 @@ pub fn fetch_squads_multisig(
 /// Compile `instructions` into a Squads `TransactionMessage` using Solana's official v0
 /// message compiler, then translate the result into the Squads wire format.
 ///
-/// `payer` becomes `account_keys[0]` — the required fee-payer/signer — matching Solana's
+/// `payer` becomes `account_keys[0]` - the required fee-payer/signer - matching Solana's
 /// account-ordering invariant. For Squads inner messages this is the vault PDA that signs
 /// via CPI. `address_lookup_table_accounts` lets callers pull accounts from on-chain lookup
 /// tables; pass `&[]` to keep every account static.
@@ -130,7 +130,7 @@ pub fn build_squads_transaction_message(
     })
 }
 
-/// Returns true for transient node/network errors worth retrying — not deterministic
+/// Returns true for transient node/network errors worth retrying - not deterministic
 /// failures like a preflight/program error.
 fn is_transient_rpc_error(err: &ClientError) -> bool {
     match &*err.kind {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -347,6 +347,52 @@ pub fn prompt_for_voting_key(config: &Config) -> Result<Pubkey> {
     Ok(key)
 }
 
+/// Resolve a `--network` argument to an RPC URL: an exact configured URL, a
+/// configured network's display name (devnet/testnet/mainnet, case-insensitive),
+/// or any explicit http(s) URL.
+pub fn resolve_network_arg(config: &Config, arg: &str) -> Result<String> {
+    let configured = if config.networks.is_empty() {
+        vec![DEFAULT_DEVNET_URL.to_string()]
+    } else {
+        config.networks.clone()
+    };
+    if let Some(url) = configured.iter().find(|url| url.as_str() == arg) {
+        return Ok(url.clone());
+    }
+    if let Some(url) = configured
+        .iter()
+        .find(|url| get_network_display(url).eq_ignore_ascii_case(arg))
+    {
+        return Ok(url.clone());
+    }
+    if arg.starts_with("http://") || arg.starts_with("https://") {
+        return Ok(arg.to_string());
+    }
+    Err(eyre::eyre!(
+        "Unknown network '{}'. Use a configured network name or URL: {}",
+        arg,
+        configured.join(", ")
+    ))
+}
+
+/// Prompt for a pubkey with an optional editable default pre-filled.
+pub fn prompt_for_pubkey_with_default(prompt: &str, default: Option<&str>) -> Result<Pubkey> {
+    loop {
+        let mut text = Text::new(prompt);
+        if let Some(default) = default {
+            text = text.with_default(default);
+        }
+        let input = text.prompt()?;
+        match Pubkey::from_str(input.trim()) {
+            Ok(key) => return Ok(key),
+            Err(_) => println!(
+                "  {} Invalid public key, please try again.",
+                "❌".bright_red()
+            ),
+        }
+    }
+}
+
 pub fn prompt_for_pubkey(prompt: &str) -> Result<Pubkey> {
     let input = Text::new(prompt).prompt()?;
     match Pubkey::from_str(&input) {
@@ -889,4 +935,42 @@ pub fn check_fee_payer_balance_on_networks(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_network_arg_by_url_name_or_passthrough() {
+        let config = Config {
+            networks: vec![
+                "https://api.devnet.solana.com".to_string(),
+                "https://api.mainnet.solana.com".to_string(),
+            ],
+            ..Config::default()
+        };
+
+        // Exact configured URL.
+        assert_eq!(
+            resolve_network_arg(&config, "https://api.devnet.solana.com").unwrap(),
+            "https://api.devnet.solana.com"
+        );
+        // Display name, case-insensitive, resolves to the configured URL.
+        assert_eq!(
+            resolve_network_arg(&config, "Mainnet").unwrap(),
+            "https://api.mainnet.solana.com"
+        );
+        // Unconfigured but explicit URLs pass through.
+        assert_eq!(
+            resolve_network_arg(&config, "http://127.0.0.1:8899").unwrap(),
+            "http://127.0.0.1:8899"
+        );
+        // Anything else is an error naming the configured options.
+        let err = resolve_network_arg(&config, "testnet")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Unknown network"));
+        assert!(err.contains("https://api.devnet.solana.com"));
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -307,6 +307,46 @@ pub fn prompt_for_threshold_with_max(max_members: usize) -> Result<u16> {
     }
 }
 
+/// Prompt for the voting key with the saved config default pre-filled and
+/// editable, so a saved identity is one Enter away but never silently binding.
+/// Offers to persist a newly entered key as the default.
+///
+/// `config` must be the full user config (not a narrowed clone), since saving
+/// writes it back to disk.
+pub fn prompt_for_voting_key(config: &Config) -> Result<Pubkey> {
+    let saved = config.voting_key.as_deref();
+    let key = loop {
+        let mut prompt = Text::new("Enter the voting key (EOA or parent multisig):");
+        if let Some(saved) = saved {
+            prompt = prompt.with_default(saved);
+        }
+        let input = prompt.prompt()?;
+        match Pubkey::from_str(input.trim()) {
+            Ok(key) => break key,
+            Err(_) => println!(
+                "  {} Invalid public key, please try again.",
+                "❌".bright_red()
+            ),
+        }
+    };
+
+    let changed = saved != Some(key.to_string().as_str());
+    if changed
+        && !is_e2e_test_mode()
+        && !is_assume_yes()
+        && Confirm::new("Save as default voting key for future commands?")
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+    {
+        let mut updated = config.clone();
+        updated.voting_key = Some(key.to_string());
+        save_config(&updated)?;
+        println!("  {} Voting key saved to config.", "✓".bright_green());
+    }
+    Ok(key)
+}
+
 pub fn prompt_for_pubkey(prompt: &str) -> Result<Pubkey> {
     let input = Text::new(prompt).prompt()?;
     match Pubkey::from_str(&input) {


### PR DESCRIPTION
The proposal actions menu used to ask for a proposal index from memory, and asked you to declare the transaction type before seeing what proposals exist.

### What changed
- Picking a proposal now shows a list fetched from chain, with what each one does, its status, and vote counts:

  `#2 — Revoke feature gate — Active — 1 approval(s), 0 rejection(s)`

  The kind is classified from the on-chain transaction shape (config tx =
  rekey, Feature Gate program ix = revoke, System-only = activate), so routing
  no longer depends on the user declaring it correctly. Create still asks for
  the type, since there is nothing to infer from yet.
- Proposals the chosen action can no longer apply to (executed, rejected,
  cancelled, stale) are filtered out, with a note. The Squads staleness nuance
  is encoded and unit tested: a stale approved vault tx can still execute, a
  stale config tx cannot. Manual index entry stays as the escape hatch.
- The network is chosen once up front; downstream flows stop re-prompting.
- The flow dispatches through the same `proposal_command` as the CLI
  subcommands, so the two entry points cannot drift.
- The voting key is prompted with the saved default pre-filled and editable,
  never silently applied; entering a new key offers to save it.
- Esc in any prompt cancels back to the main menu instead of exiting the tool.