### PR TITLE
UX polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,9 +955,11 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sha256-hasher",
+ "solana-signature",
  "solana-signer",
  "solana-system-interface 3.2.0",
  "solana-transaction",
+ "solana-transaction-status-client-types",
  "tabled",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ solana-clap-v3-utils = "=3.1.14"
 solana-instruction = {version = "=3.4.0", features = ["bincode"]}
 solana-pubkey = {version = "=4.2.0", features = ["borsh", "curve25519"]}
 solana-keypair = "=3.1.2"
+solana-signature = "=3.4.1"
 solana-signer = "=3.0.1"
+solana-transaction-status-client-types = "=3.1.14"
 solana-message = "=3.1.0"
 solana-transaction = {version = "=3.1.0", features = ["serde", "bincode"]}
 solana-compute-budget-interface = "=3.0.0"

--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -46,10 +46,12 @@ pub fn interactive_mode() -> Result<()> {
             "Proposal Actions (Approve/Reject/Execute)" => {
                 handle_proposal_action(&config, &mut last_multisig)
             }
-            "Show feature gate multisig details" => Text::new("Enter the main multisig address:")
-                .prompt()
-                .map_err(eyre::Report::from)
-                .and_then(|address| show_command(&config, Some(address))),
+            "Show feature gate multisig details" => {
+                Text::new("Enter the feature gate multisig address:")
+                    .prompt()
+                    .map_err(eyre::Report::from)
+                    .and_then(|address| show_command(&config, Some(address)))
+            }
             "Verify feature gate multisig" => Text::new("Enter the feature gate multisig address:")
                 .prompt()
                 .map_err(eyre::Report::from)
@@ -325,13 +327,33 @@ fn prompt_for_proposal_index(
     let mut entries: Vec<(u64, ProposalKind)> = Vec::new();
     let mut options: Vec<String> = Vec::new();
     let mut skipped = 0u64;
+    let mut known_max: Option<u64> = None;
     match fetch_squads_multisig(rpc_client, multisig, "multisig") {
         Ok(ms) if ms.transaction_index > 0 => {
+            known_max = Some(ms.transaction_index);
             let first = ms.transaction_index.saturating_sub(MAX_LISTED - 1).max(1);
+            if first > 1 {
+                Output::info(&format!(
+                    "Showing the last {MAX_LISTED} proposals; older ones (#1-#{}) via manual entry.",
+                    first - 1
+                ));
+            }
             for index in first..=ms.transaction_index {
                 let (proposal_pda, _) = get_proposal_pda(multisig, index);
-                let Ok(account) = rpc_client.get_account(&proposal_pda) else {
-                    continue;
+                let account = match rpc_client.get_account(&proposal_pda) {
+                    Ok(account) => account,
+                    Err(e) => {
+                        let msg = e.to_string();
+                        // Missing accounts are normal (closed/reclaimed); only a
+                        // real fetch failure deserves a warning, so the list is
+                        // never silently incomplete.
+                        if !msg.contains("AccountNotFound")
+                            && !msg.contains("could not find account")
+                        {
+                            Output::warning(&format!("Could not fetch proposal #{index}: {e}"));
+                        }
+                        continue;
+                    }
                 };
                 let Ok(proposal) = deserialize_squads_account::<Proposal>(
                     &account.data,
@@ -385,6 +407,13 @@ fn prompt_for_proposal_index(
     let index: u64 = index_str
         .parse()
         .map_err(|_| eyre::eyre!("Invalid proposal index"))?;
+    if let Some(max) = known_max {
+        if index == 0 || index > max {
+            return Err(eyre::eyre!(
+                "Proposal index must be between 1 and {max} for this multisig"
+            ));
+        }
+    }
     Ok((index, describe_transaction(rpc_client, multisig, index)))
 }
 

--- a/src/commands/transaction_generation.rs
+++ b/src/commands/transaction_generation.rs
@@ -427,7 +427,7 @@ fn approve_and_maybe_execute_parent(
         VersionedTransaction::try_new(VersionedMessage::V0(approve_msg), &[fee_payer_signer])?;
     let approve_sig = crate::provision::send_and_confirm_transaction(&approve_tx, rpc_client)
         .map_err(|e| eyre::eyre!("Failed to approve parent proposal: {}", e))?;
-    output::Output::field("Parent proposal approved (sig):", &approve_sig);
+    output::Output::field("Parent proposal approved (sig)", &approve_sig);
 
     // If approvals meet threshold, offer to execute the parent proposal now
     let (approved, threshold, _status) =
@@ -454,7 +454,7 @@ fn approve_and_maybe_execute_parent(
             VersionedTransaction::try_new(VersionedMessage::V0(exec_msg), &[fee_payer_signer])?;
         let exec_sig = crate::provision::send_and_confirm_transaction(&exec_tx, rpc_client)
             .map_err(|e| eyre::eyre!("Failed to execute parent proposal: {}", e))?;
-        output::Output::field("Parent proposal executed (sig):", &exec_sig);
+        output::Output::field("Parent proposal executed (sig)", &exec_sig);
 
         let success_message = match operation {
             ProposalAction::Approve => "Child proposal has been approved via parent multisig!",
@@ -530,15 +530,12 @@ fn handle_parent_multisig_flow(
         "Parent Multisig {} Transaction Details:",
         permission_name
     ));
-    output::Output::field("Parent Multisig:", &parent_multisig.to_string());
-    output::Output::field(
-        "Child Multisig:",
-        &feature_gate_multisig_address.to_string(),
-    );
-    output::Output::field("Parent Transaction Index:", &parent_next_index.to_string());
-    output::Output::field("Child Proposal Index:", &proposal_index.to_string());
-    output::Output::field("Transaction Type:", kind.label());
-    output::Output::field("Action:", &action_description);
+    output::Output::field("Parent Multisig", &parent_multisig.to_string());
+    output::Output::field("Child Multisig", &feature_gate_multisig_address.to_string());
+    output::Output::field("Parent Transaction Index", &parent_next_index.to_string());
+    output::Output::field("Child Proposal Index", &proposal_index.to_string());
+    output::Output::field("Transaction Type", kind.label());
+    output::Output::field("Action", &action_description);
 
     // Ask for confirmation before creating the parent multisig proposal
     let confirmation_prompt = match operation {
@@ -584,8 +581,8 @@ fn handle_parent_multisig_flow(
         Some(crate::constants::DEFAULT_COMPUTE_UNITS),
         blockhash,
     )?;
-    output::Output::address("Parent transaction PDA:", &tx_pda.to_string());
-    output::Output::address("Parent proposal PDA:", &prop_pda.to_string());
+    output::Output::address("Parent transaction PDA", &tx_pda.to_string());
+    output::Output::address("Parent proposal PDA", &prop_pda.to_string());
 
     let transaction =
         VersionedTransaction::try_new(VersionedMessage::V0(msg), &[fee_payer_signer])?;
@@ -596,7 +593,7 @@ fn handle_parent_multisig_flow(
         "Parent Multisig {} Transaction Created & Sent:",
         permission_name
     ));
-    output::Output::field("Signature:", &signature);
+    output::Output::field("Signature", &signature);
 
     // Offer to approve the parent proposal immediately
     if confirm_action("Approve this parent proposal now?", true) {
@@ -700,7 +697,7 @@ pub fn reject_common_feature_gate_proposal(
 
     let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
         .map_err(|e| eyre::eyre!("Failed to send reject transaction: {}", e))?;
-    output::Output::field("Reject transaction sent successfully:", &signature);
+    output::Output::field("Reject transaction sent successfully", &signature);
     Ok(())
 }
 
@@ -817,7 +814,7 @@ pub fn execute_common_feature_gate_proposal(
     // Send and confirm
     let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
         .map_err(|e| eyre::eyre!("Failed to execute proposal: {}", e))?;
-    output::Output::field("Proposal executed (sig):", &signature);
+    output::Output::field("Proposal executed (sig)", &signature);
     Ok(())
 }
 
@@ -869,7 +866,7 @@ pub fn create_feature_gate_proposal(
         // voting_key is the parent multisig address, derive the vault PDA from it
         let parent_vault_pda = crate::squads::get_vault_pda(&voting_key, 0).0;
         output::Output::field(
-            "Parent vault PDA (creator/rent_payer):",
+            "Parent vault PDA (creator/rent_payer)",
             &parent_vault_pda.to_string(),
         );
 
@@ -891,7 +888,7 @@ pub fn create_feature_gate_proposal(
         )?;
 
         output::Output::field(
-            "Vault proposal created at index:",
+            "Vault proposal created at index",
             &next_tx_index.to_string(),
         );
 
@@ -931,8 +928,8 @@ pub fn create_feature_gate_proposal(
     let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
         .map_err(|e| eyre::eyre!("Failed to create {} proposal: {}", kind.label(), e))?;
 
-    output::Output::field("Vault proposal index:", &next_tx_index.to_string());
-    output::Output::field("Create proposal signature:", &signature);
+    output::Output::field("Vault proposal index", &next_tx_index.to_string());
+    output::Output::field("Create proposal signature", &signature);
 
     output::Output::info(
         "Next step: Gather approvals from other members, then execute the proposal.",
@@ -1083,8 +1080,8 @@ pub fn rekey_multisig_feature_gate(
     // Send and confirm
     let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
         .map_err(|e| eyre::eyre!("Failed to create rekey proposal: {}", e))?;
-    output::Output::field("Rekey proposal created (sig):", &signature);
-    output::Output::field("Proposal index:", &next_tx_index.to_string());
+    output::Output::field("Rekey proposal created (sig)", &signature);
+    output::Output::field("Proposal index", &next_tx_index.to_string());
 
     // Offer to approve the config proposal immediately
     if Confirm::new("Approve this config proposal now?")
@@ -1281,6 +1278,6 @@ pub fn execute_common_config_change(
     // Send and confirm
     let signature = crate::provision::send_and_confirm_transaction(&transaction, &rpc_client)
         .map_err(|e| eyre::eyre!("Failed to execute config change: {}", e))?;
-    output::Output::field("Config change executed (sig):", &signature);
+    output::Output::field("Config change executed (sig)", &signature);
     Ok(())
 }

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -33,6 +33,7 @@ use solana_rpc_client_api::request::{RpcError, RpcResponseErrorData};
 use solana_rpc_client_api::response::RpcSimulateTransactionResult;
 use solana_signer::Signer;
 use solana_transaction::versioned::VersionedTransaction;
+use std::str::FromStr;
 use std::time::Duration;
 
 /// Creates an RPC client with consistent commitment configuration
@@ -51,6 +52,26 @@ pub fn fetch_squads_multisig(
         .get_account(address)
         .map_err(|e| eyre!("Failed to fetch {} {}: {}", account_kind, address, e))?;
     if acc.owner != SQUADS_MULTISIG_PROGRAM_ID {
+        // The most common mix-up: pasting the feature gate account (the
+        // multisig's vault PDA) instead of the multisig itself.
+        if acc.owner == crate::feature_gate_program::FEATURE_GATE_PROGRAM_ID {
+            let hint = find_multisig_for_feature_account(rpc_client, address)
+                .map(|multisig| format!(" Its multisig is {multisig}."))
+                .unwrap_or_default();
+            return Err(eyre!(
+                "{} {} is a feature gate account, not the multisig. Enter the multisig address the feature gate derives from (the feature gate is its vault 0).{}",
+                account_kind,
+                address,
+                hint
+            ));
+        }
+        if acc.owner == solana_system_interface::program::ID {
+            return Err(eyre!(
+                "{} {} is a plain system account (a wallet, or an unactivated feature gate), not a multisig. Enter the multisig address itself.",
+                account_kind,
+                address
+            ));
+        }
         return Err(eyre!(
             "{} {} is not owned by the Squads program (owner: {})",
             account_kind,
@@ -59,6 +80,66 @@ pub fn fetch_squads_multisig(
         ));
     }
     deserialize_squads_account(&acc.data, MULTISIG_ACCOUNT_DISCRIMINATOR, account_kind)
+}
+
+/// Best-effort reverse lookup from a feature gate account to its multisig.
+///
+/// The vault-PDA derivation is one-way, but the transaction that activated the
+/// feature was executed by the multisig, so its account keys contain it. Scan
+/// the feature account's recent transactions for a key whose vault 0 derives
+/// to the feature account; the match is proof, not a guess.
+pub fn find_multisig_for_feature_account(
+    rpc_client: &RpcClient,
+    feature_account: &Pubkey,
+) -> Option<Pubkey> {
+    const MAX_TRANSACTIONS_SCANNED: usize = 5;
+
+    let signatures = rpc_client
+        .get_signatures_for_address(feature_account)
+        .ok()?;
+    for info in signatures.iter().take(MAX_TRANSACTIONS_SCANNED) {
+        let Ok(signature) = solana_signature::Signature::from_str(&info.signature) else {
+            continue;
+        };
+        let Ok(tx) = rpc_client.get_transaction_with_config(
+            &signature,
+            solana_rpc_client_api::config::RpcTransactionConfig {
+                encoding: Some(
+                    solana_transaction_status_client_types::UiTransactionEncoding::Base64,
+                ),
+                commitment: Some(rpc_client.commitment()),
+                max_supported_transaction_version: Some(0),
+            },
+        ) else {
+            continue;
+        };
+        let Some(decoded) = tx.transaction.transaction.decode() else {
+            continue;
+        };
+        for key in decoded.message.static_account_keys() {
+            if get_vault_pda(key, 0).0 == *feature_account {
+                return Some(*key);
+            }
+        }
+        // Accounts referenced via address lookup tables are absent from the
+        // static keys, but the RPC meta carries them already resolved.
+        let loaded: Option<solana_transaction_status_client_types::UiLoadedAddresses> = tx
+            .transaction
+            .meta
+            .as_ref()
+            .and_then(|meta| Option::from(meta.loaded_addresses.clone()));
+        if let Some(loaded) = loaded {
+            for addr in loaded.writable.iter().chain(loaded.readonly.iter()) {
+                let Ok(key) = Pubkey::from_str(addr) else {
+                    continue;
+                };
+                if get_vault_pda(&key, 0).0 == *feature_account {
+                    return Some(key);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Compile `instructions` into a Squads `TransactionMessage` using Solana's official v0

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -36,7 +36,7 @@ use feature_gate_multisig_tool::commands::verify::verify_command;
 use feature_gate_multisig_tool::feature_gate_program::{
     FEATURE_ACCOUNT_SIZE, FEATURE_GATE_PROGRAM_ID,
 };
-use feature_gate_multisig_tool::provision::create_multisig;
+use feature_gate_multisig_tool::provision::{create_multisig, fetch_squads_multisig};
 use feature_gate_multisig_tool::squads::{
     get_proposal_pda, get_vault_pda, Member, Permissions, Proposal, ProposalStatus,
     PERMISSION_VOTE, SQUADS_MULTISIG_PROGRAM_ID,
@@ -1226,7 +1226,7 @@ fn rpc_e2e_9_verify_checks() {
 
     // Build an isolated EOA multisig so the feature-state transition is
     // deterministic and independent of the other tests.
-    let (config, child_multisig, _vault, eoa_pubkeys, eoa_keypaths) =
+    let (config, child_multisig, child_vault, eoa_pubkeys, eoa_keypaths) =
         setup_eoa_multisig(&client, "eoa_test9", 2);
 
     // Before execution the feature account (vault 0) is unallocated -> Fresh.
@@ -1297,6 +1297,23 @@ fn rpc_e2e_9_verify_checks() {
         "activated feature account should be rent-exempt"
     );
     println!("✅ Feature gate classified Pending after activation; verify checks complete");
+
+    // Pasting the feature gate account instead of the multisig must fail with
+    // a hint that names the actual multisig (reverse lookup via the activation
+    // transaction's account keys).
+    let err = match fetch_squads_multisig(&client, &child_vault, "multisig") {
+        Ok(_) => panic!("vault address must not pass as a multisig"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("feature gate account"),
+        "error should explain the mix-up: {err}"
+    );
+    assert!(
+        err.contains(&child_multisig.to_string()),
+        "error should name the multisig: {err}"
+    );
+    println!("✅ Wrong-address error names the multisig via reverse lookup");
 
     // Smoke test the full verify command end to end: the network loop, all three
     // display sections, and (skipped, single network) cross-network consistency.


### PR DESCRIPTION
## UX polish: clearer errors, output cleanup, picker hardening

- Fixed doubled colons in ~20 output lines (`sent successfully:: <sig>`)
- Unified prompt wording: "feature gate multisig address" everywhere
  (one prompt still said "main multisig address")
- Pasting the wrong address now explains itself: a feature gate account or a
  plain system account each get a tailored error instead of a generic owner
  mismatch
- When the pasted address is a feature gate account, the tool looks up its
  multisig from transaction history: the activation execute was signed by the
  multisig, so its account keys contain it, and a vault derivation match is
  proof rather than a guess. Scans both static and lookup table loaded keys,
  so ALT built transactions are covered too. The error then names the actual
  multisig. Covered by an E2E assertion.
- Proposal picker hardening: warns on real RPC failures instead of silently
  shrinking the list, notes when older proposals fall outside the 10 item
  window, and range checks manual index entry
