### PR TITLE
show flow redesign

### DIFF
--- a/src/commands/interactive.rs
+++ b/src/commands/interactive.rs
@@ -1,15 +1,13 @@
+use crate::commands::proposal::{describe_transaction, proposal_status_label, ProposalKind};
 use crate::commands::{
     config_command, create_command, proposal_command, show_command, verify_command,
     ProposalCommand, ProposalCommandArgs, TransactionKind,
 };
-use crate::feature_gate_program::FEATURE_GATE_PROGRAM_ID;
 use crate::output::Output;
 use crate::provision::{create_rpc_client, fetch_squads_multisig};
 use crate::squads::{
-    deserialize_squads_account, get_proposal_pda, get_transaction_pda, get_vault_pda,
-    ConfigTransaction, Proposal, ProposalStatus, VaultTransaction,
-    CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR, PROPOSAL_ACCOUNT_DISCRIMINATOR,
-    SQUADS_MULTISIG_PROGRAM_ID, VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+    deserialize_squads_account, get_proposal_pda, get_vault_pda, Proposal, ProposalStatus,
+    PROPOSAL_ACCOUNT_DISCRIMINATOR,
 };
 use crate::utils::*;
 use eyre::Result;
@@ -50,7 +48,7 @@ pub fn interactive_mode() -> Result<()> {
                 Text::new("Enter the feature gate multisig address:")
                     .prompt()
                     .map_err(eyre::Report::from)
-                    .and_then(|address| show_command(&config, Some(address)))
+                    .and_then(|address| show_command(&config, Some(address), None, None))
             }
             "Verify feature gate multisig" => Text::new("Enter the feature gate multisig address:")
                 .prompt()
@@ -188,104 +186,6 @@ fn prompt_for_transaction_kind() -> Result<Option<TransactionKind>> {
         "Rekey Multisig (this will brick the multisig)" => Some(TransactionKind::Rekey),
         _ => None,
     })
-}
-
-/// What a proposal's companion transaction does, classified from its on-chain
-/// shape. The tool only creates three forms: activate (System-program
-/// allocate+assign), revoke (an instruction to the Feature Gate program), and
-/// rekey (a config transaction).
-#[derive(Clone, Copy)]
-enum ProposalKind {
-    Activate,
-    Revoke,
-    Rekey,
-    ChildAction,
-    Other,
-    Unknown,
-}
-
-impl ProposalKind {
-    fn label(self) -> &'static str {
-        match self {
-            ProposalKind::Activate => "Activate feature gate",
-            ProposalKind::Revoke => "Revoke feature gate",
-            ProposalKind::Rekey => "Rekey (config change)",
-            ProposalKind::ChildAction => "Child multisig action",
-            ProposalKind::Other => "Vault transaction",
-            ProposalKind::Unknown => "Unknown",
-        }
-    }
-
-    fn transaction_kind(self) -> Option<TransactionKind> {
-        match self {
-            ProposalKind::Activate => Some(TransactionKind::Activate),
-            ProposalKind::Revoke => Some(TransactionKind::Revoke),
-            ProposalKind::Rekey => Some(TransactionKind::Rekey),
-            ProposalKind::ChildAction | ProposalKind::Other | ProposalKind::Unknown => None,
-        }
-    }
-}
-
-fn describe_transaction(rpc_client: &RpcClient, multisig: &Pubkey, index: u64) -> ProposalKind {
-    let (transaction_pda, _) = get_transaction_pda(multisig, index);
-    let Ok(account) = rpc_client.get_account(&transaction_pda) else {
-        return ProposalKind::Unknown;
-    };
-
-    if deserialize_squads_account::<ConfigTransaction>(
-        &account.data,
-        CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR,
-        "config transaction",
-    )
-    .is_ok()
-    {
-        return ProposalKind::Rekey;
-    }
-
-    let Ok(vault_tx) = deserialize_squads_account::<VaultTransaction>(
-        &account.data,
-        VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
-        "vault transaction",
-    ) else {
-        return ProposalKind::Unknown;
-    };
-
-    let programs: Vec<&Pubkey> = vault_tx
-        .message
-        .instructions
-        .iter()
-        .filter_map(|ix| {
-            vault_tx
-                .message
-                .account_keys
-                .get(ix.program_id_index as usize)
-        })
-        .collect();
-
-    if programs.iter().any(|p| **p == FEATURE_GATE_PROGRAM_ID) {
-        ProposalKind::Revoke
-    } else if programs
-        .iter()
-        .all(|p| **p == solana_system_interface::program::ID)
-    {
-        ProposalKind::Activate
-    } else if programs.iter().any(|p| **p == SQUADS_MULTISIG_PROGRAM_ID) {
-        ProposalKind::ChildAction
-    } else {
-        ProposalKind::Other
-    }
-}
-
-fn proposal_status_label(status: &ProposalStatus) -> &'static str {
-    match status {
-        ProposalStatus::Draft { .. } => "Draft",
-        ProposalStatus::Active { .. } => "Active",
-        ProposalStatus::Rejected { .. } => "Rejected",
-        ProposalStatus::Approved { .. } => "Approved",
-        ProposalStatus::Executing => "Executing",
-        ProposalStatus::Executed { .. } => "Executed",
-        ProposalStatus::Cancelled { .. } => "Cancelled",
-    }
 }
 
 /// Whether `action` can still be performed on a proposal, given its status and

--- a/src/commands/proposal.rs
+++ b/src/commands/proposal.rs
@@ -8,13 +8,20 @@ use crate::commands::transaction_generation::{
     execute_common_feature_gate_proposal, reject_common_feature_gate_proposal,
     rekey_multisig_feature_gate, TransactionKind,
 };
+use crate::feature_gate_program::FEATURE_GATE_PROGRAM_ID;
 use crate::output::Output;
+use crate::squads::{
+    deserialize_squads_account, get_transaction_pda, ConfigTransaction, ProposalStatus,
+    VaultTransaction, CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR, SQUADS_MULTISIG_PROGRAM_ID,
+    VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+};
 use crate::utils::{
     is_assume_yes, is_e2e_test_mode, prompt_for_fee_payer_path, prompt_for_pubkey, save_config,
     Config,
 };
 use eyre::Result;
 use solana_pubkey::Pubkey;
+use solana_rpc_client::rpc_client::RpcClient;
 use std::str::FromStr;
 
 /// Which proposal action a subcommand performs.
@@ -125,4 +132,106 @@ fn resolve_voting_key(config: &Config, flag: Option<&str>) -> Result<Pubkey> {
         Output::success("Voting key saved to config.");
     }
     Ok(key)
+}
+
+/// What a proposal's companion transaction does, classified from its on-chain
+/// shape. The tool only creates three forms: activate (System-program
+/// allocate+assign), revoke (an instruction to the Feature Gate program), and
+/// rekey (a config transaction).
+#[derive(Clone, Copy)]
+pub(crate) enum ProposalKind {
+    Activate,
+    Revoke,
+    Rekey,
+    ChildAction,
+    Other,
+    Unknown,
+}
+
+impl ProposalKind {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            ProposalKind::Activate => "Activate feature gate",
+            ProposalKind::Revoke => "Revoke feature gate",
+            ProposalKind::Rekey => "Rekey (config change)",
+            ProposalKind::ChildAction => "Child multisig action",
+            ProposalKind::Other => "Vault transaction",
+            ProposalKind::Unknown => "Unknown",
+        }
+    }
+
+    pub(crate) fn transaction_kind(self) -> Option<TransactionKind> {
+        match self {
+            ProposalKind::Activate => Some(TransactionKind::Activate),
+            ProposalKind::Revoke => Some(TransactionKind::Revoke),
+            ProposalKind::Rekey => Some(TransactionKind::Rekey),
+            ProposalKind::ChildAction | ProposalKind::Other | ProposalKind::Unknown => None,
+        }
+    }
+}
+
+pub(crate) fn describe_transaction(
+    rpc_client: &RpcClient,
+    multisig: &Pubkey,
+    index: u64,
+) -> ProposalKind {
+    let (transaction_pda, _) = get_transaction_pda(multisig, index);
+    let Ok(account) = rpc_client.get_account(&transaction_pda) else {
+        return ProposalKind::Unknown;
+    };
+
+    if deserialize_squads_account::<ConfigTransaction>(
+        &account.data,
+        CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+        "config transaction",
+    )
+    .is_ok()
+    {
+        return ProposalKind::Rekey;
+    }
+
+    let Ok(vault_tx) = deserialize_squads_account::<VaultTransaction>(
+        &account.data,
+        VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
+        "vault transaction",
+    ) else {
+        return ProposalKind::Unknown;
+    };
+
+    let programs: Vec<&Pubkey> = vault_tx
+        .message
+        .instructions
+        .iter()
+        .filter_map(|ix| {
+            vault_tx
+                .message
+                .account_keys
+                .get(ix.program_id_index as usize)
+        })
+        .collect();
+
+    if programs.iter().any(|p| **p == FEATURE_GATE_PROGRAM_ID) {
+        ProposalKind::Revoke
+    } else if programs
+        .iter()
+        .all(|p| **p == solana_system_interface::program::ID)
+    {
+        ProposalKind::Activate
+    } else if programs.iter().any(|p| **p == SQUADS_MULTISIG_PROGRAM_ID) {
+        ProposalKind::ChildAction
+    } else {
+        ProposalKind::Other
+    }
+}
+
+pub(crate) fn proposal_status_label(status: &ProposalStatus) -> &'static str {
+    match status {
+        ProposalStatus::Draft { .. } => "Draft",
+        ProposalStatus::Active { .. } => "Active",
+        ProposalStatus::Rejected { .. } => "Rejected",
+        ProposalStatus::Approved { .. } => "Approved",
+        ProposalStatus::Executing => "Executing",
+        ProposalStatus::Executed { .. } => "Executed",
+        ProposalStatus::Cancelled { .. } => "Cancelled",
+    }
 }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,23 +1,35 @@
-use crate::constants::*;
+use crate::commands::proposal::{describe_transaction, proposal_status_label, ProposalKind};
+use crate::commands::verify::report_cross_network_consistency;
+use crate::output::Output;
 use crate::provision::{create_rpc_client, fetch_squads_multisig, get_account_data_with_retry};
 use crate::squads::{
     deserialize_squads_account, get_proposal_pda, get_transaction_pda, get_vault_pda, ConfigAction,
     ConfigTransaction, Multisig, Proposal, ProposalStatus, VaultTransaction,
-    CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR, PROPOSAL_ACCOUNT_DISCRIMINATOR,
+    CONFIG_TRANSACTION_ACCOUNT_DISCRIMINATOR, PERMISSION_VOTE, PROPOSAL_ACCOUNT_DISCRIMINATOR,
     VAULT_TRANSACTION_ACCOUNT_DISCRIMINATOR,
 };
 use crate::utils::*;
+use crate::verification::{
+    is_autonomous, is_mainnet_cluster, is_rekeyed, known_signer_name, member_set_warnings,
+    multisig_safety_warnings, program_warnings, verify_feature_gate, verify_squads_program,
+    FeatureGateStatus,
+};
 use colored::*;
 use eyre::Result;
 use inquire::Select;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::rpc_client::RpcClient;
+use std::io::IsTerminal;
 use std::str::FromStr;
 use tabled::{settings::Style, Table, Tabled};
 
-pub fn show_command(config: &Config, address: Option<String>) -> Result<()> {
+pub fn show_command(
+    config: &Config,
+    address: Option<String>,
+    network: Option<String>,
+    detail_index: Option<u64>,
+) -> Result<()> {
     let address = if let Some(addr) = address {
-        // Validate provided address
         match Pubkey::from_str(&addr) {
             Ok(_) => addr,
             Err(_) => {
@@ -30,57 +42,315 @@ pub fn show_command(config: &Config, address: Option<String>) -> Result<()> {
             }
         }
     } else {
-        validate_pubkey_with_retry("Enter multisig address:")?.to_string()
+        validate_pubkey_with_retry("Enter the feature gate multisig address:")?.to_string()
     };
-    show_multisig(config, &address)
+    let rpc_url = match network {
+        Some(arg) => resolve_network_arg(config, &arg)?,
+        None => choose_network_from_config(config)?,
+    };
+    show_multisig(config, &address, &rpc_url, detail_index)
 }
 
-fn show_multisig(config: &Config, address: &str) -> Result<()> {
-    // Parse the multisig address
+fn show_multisig(
+    config: &Config,
+    address: &str,
+    rpc_url: &str,
+    detail_index: Option<u64>,
+) -> Result<()> {
     let multisig_pubkey =
         Pubkey::from_str(address).map_err(|_| eyre::eyre!("Invalid multisig address format"))?;
-
-    println!(
-        "{}",
-        "🔍 Fetching multisig details...".bright_yellow().bold()
-    );
-    println!();
-
-    let networks_to_try = if !config.networks.is_empty() {
-        config.networks.clone()
-    } else {
-        vec![DEFAULT_DEVNET_URL.to_string()]
-    };
-
-    let rpc_url: String =
-        Select::new("Which network would you like to query?", networks_to_try).prompt()?;
-
-    println!("🌐 Trying network: {}", rpc_url.bright_white());
-
-    let rpc_client = create_rpc_client(&rpc_url);
+    let rpc_client = create_rpc_client(rpc_url);
     // fetch_squads_multisig validates owner == Squads program before deserializing,
     // so a spoofed look-alike account is rejected rather than rendered as a multisig.
     let multisig = fetch_squads_multisig(&rpc_client, &multisig_pubkey, "multisig")?;
+    let vault0 = get_vault_pda(&multisig_pubkey, 0).0;
 
+    // Classify every transaction up front: it feeds the proposals table and
+    // tells us what this multisig is. A parent (voting) multisig's proposals
+    // wrap actions on child multisigs; a feature gate multisig's proposals
+    // act on the feature account.
+    let kinds: Vec<ProposalKind> = (1..=multisig.transaction_index)
+        .map(|index| describe_transaction(&rpc_client, &multisig_pubkey, index))
+        .collect();
+    let looks_like_parent = kinds
+        .iter()
+        .any(|kind| matches!(kind, ProposalKind::ChildAction));
+
+    println!();
+    let networks = if config.networks.is_empty() {
+        vec![rpc_url.to_string()]
+    } else {
+        config.networks.clone()
+    };
+    let mut network_multisigs: Vec<(&str, Multisig)> = Vec::new();
+
+    if looks_like_parent {
+        // Vault 0 of a parent is its voting identity on child multisigs, not a
+        // feature gate; reporting a "feature state" for it would be misleading.
+        Output::header(&format!("📋 Squads Multisig {multisig_pubkey}"));
+        Output::info(
+            "This looks like a parent (voting) multisig: its proposals act on child multisigs.",
+        );
+        Output::field(
+            "Voting identity (vault 0)",
+            &format!("{vault0} (appears as a member on child multisigs)"),
+        );
+        for url in &networks {
+            let client = create_rpc_client(url);
+            if let Ok(ms) = fetch_squads_multisig(&client, &multisig_pubkey, "multisig") {
+                network_multisigs.push((get_network_display(url), ms));
+            }
+        }
+    } else {
+        Output::header(&format!("📋 Feature Gate Multisig {multisig_pubkey}"));
+        Output::field("Feature gate (vault 0)", &vault0.to_string());
+
+        // Per-network sweep: feature state (cheap, two RPC calls per network)
+        // and each network's multisig config for the drift check further down.
+        let mut states: Vec<String> = Vec::new();
+        for url in &networks {
+            let client = create_rpc_client(url);
+            let state = match verify_feature_gate(&client, &multisig_pubkey) {
+                Ok(v) => feature_status_label(&v.status),
+                Err(_) => "unreachable".to_string(),
+            };
+            states.push(format!("{}: {}", get_network_display(url), state));
+            if let Ok(ms) = fetch_squads_multisig(&client, &multisig_pubkey, "multisig") {
+                network_multisigs.push((get_network_display(url), ms));
+            }
+        }
+        Output::field("Feature state", &states.join(" | "));
+    }
+
+    let voting_members = multisig
+        .members
+        .iter()
+        .filter(|m| m.permissions.mask & PERMISSION_VOTE != 0)
+        .count();
+    Output::field(
+        "Threshold",
+        &format!(
+            "{} of {} voting members",
+            multisig.threshold, voting_members
+        ),
+    );
+    Output::field(
+        "Autonomous (config by vote)",
+        &is_autonomous(&multisig).to_string(),
+    );
+    Output::field("Time lock", &format!("{}s", multisig.time_lock));
+
+    // Rekey is per network: each cluster's multisig is independent state, so
+    // one can be frozen while the others remain active.
+    let rekeyed_on: Vec<&str> = network_multisigs
+        .iter()
+        .filter(|(_, ms)| is_rekeyed(ms))
+        .map(|(network, _)| *network)
+        .collect();
+    if !rekeyed_on.is_empty() {
+        let scope = if rekeyed_on.len() == network_multisigs.len() {
+            String::new()
+        } else {
+            "; the other networks remain active".to_string()
+        };
+        Output::warning(&format!(
+            "Rekeyed (permanently frozen) on {}: voting keys there cannot meet the threshold, so no proposal can ever pass{}.",
+            rekeyed_on.join(", "),
+            scope
+        ));
+    }
+    // The same program-authenticity check `verify` runs, on the inspected
+    // network (this is the expensive one: it downloads the program bytecode).
+    match verify_squads_program(&rpc_client) {
+        Ok(program) => {
+            let mainnet = is_mainnet_cluster(&rpc_client).unwrap_or_else(|_| is_mainnet(rpc_url));
+            let warnings = program_warnings(&program, mainnet);
+            if warnings.is_empty() {
+                let status = if mainnet {
+                    "authentic, immutable Squads v4 (bytecode verified)"
+                } else {
+                    "present; bytecode and immutability are asserted on mainnet only"
+                };
+                Output::field("Squads program", status);
+            } else {
+                for warning in warnings {
+                    Output::warning(&warning);
+                }
+            }
+        }
+        Err(e) => Output::warning(&format!("Could not verify Squads program: {e}")),
+    }
+    for warning in multisig_safety_warnings(&multisig) {
+        Output::warning(&warning);
+    }
+    for warning in member_set_warnings(&multisig) {
+        Output::warning(&warning);
+    }
+    println!();
+
+    print_members_table(&multisig);
+
+    display_proposals_summary(&rpc_client, &multisig_pubkey, &multisig, &kinds);
+
+    report_cross_network_consistency(&network_multisigs);
+
+    if let Some(index) = detail_index {
+        if index == 0 || index > multisig.transaction_index {
+            return Err(eyre::eyre!(
+                "Proposal index must be between 1 and {} for this multisig",
+                multisig.transaction_index
+            ));
+        }
+        display_full_details(&rpc_client, &multisig_pubkey, index);
+        return Ok(());
+    }
+    offer_detail_drilldown(&rpc_client, &multisig_pubkey, &multisig)
+}
+
+fn feature_status_label(status: &FeatureGateStatus) -> String {
+    match status {
+        FeatureGateStatus::Fresh => "Fresh (not activated)".to_string(),
+        FeatureGateStatus::Pending => "Pending activation".to_string(),
+        FeatureGateStatus::Activated { slot } => format!("Activated (slot {slot})"),
+        FeatureGateStatus::Unexpected { .. } => "Unexpected state".to_string(),
+    }
+}
+
+/// One row per proposal: what it does and where it stands, on the selected
+/// network. The instruction-level view stays available via the drill-down.
+fn display_proposals_summary(
+    rpc_client: &RpcClient,
+    multisig_pubkey: &Pubkey,
+    multisig: &Multisig,
+    kinds: &[ProposalKind],
+) {
+    println!("{}", "🔄 PROPOSALS".bright_yellow().bold());
+    println!();
+    if multisig.transaction_index == 0 {
+        println!("  No proposals yet.");
+        println!();
+        return;
+    }
+
+    #[derive(Tabled)]
+    struct ProposalRow {
+        #[tabled(rename = "#")]
+        index: u64,
+        #[tabled(rename = "Kind")]
+        kind: &'static str,
+        #[tabled(rename = "Status")]
+        status: String,
+        #[tabled(rename = "Approvals")]
+        approvals: String,
+        #[tabled(rename = "Rejections")]
+        rejections: String,
+    }
+
+    let mut rows = Vec::new();
+    for index in 1..=multisig.transaction_index {
+        let kind = kinds
+            .get(index as usize - 1)
+            .map_or("Unknown", |k| k.label());
+        let (proposal_pda, _) = get_proposal_pda(multisig_pubkey, index);
+        let proposal = rpc_client.get_account(&proposal_pda).ok().and_then(|acc| {
+            deserialize_squads_account::<Proposal>(
+                &acc.data,
+                PROPOSAL_ACCOUNT_DISCRIMINATOR,
+                "proposal",
+            )
+            .ok()
+        });
+        let (status, approvals, rejections) = match proposal {
+            Some(p) => (
+                proposal_status_label(&p.status).to_string(),
+                p.approved.len().to_string(),
+                p.rejected.len().to_string(),
+            ),
+            None => ("missing".to_string(), "-".to_string(), "-".to_string()),
+        };
+        rows.push(ProposalRow {
+            index,
+            kind,
+            status,
+            approvals,
+            rejections,
+        });
+    }
+    let mut table = Table::new(rows);
+    table.with(Style::rounded());
+    println!("{table}");
+    println!();
+}
+
+/// Full on-chain detail for one proposal index: PDAs, the decoded transaction
+/// at instruction level, and the raw proposal record. The debugging view.
+fn display_full_details(rpc_client: &RpcClient, multisig_pubkey: &Pubkey, tx_index: u64) {
     println!(
-        "✅ Found and verified multisig on: {}",
-        rpc_url.bright_green()
+        "{}",
+        format!("📋 TRANSACTION INDEX {}", tx_index)
+            .bright_cyan()
+            .bold()
+    );
+    println!("{}", "─".repeat(50).bright_cyan());
+    let (transaction_pda, _) = get_transaction_pda(multisig_pubkey, tx_index);
+    let (proposal_pda, _) = get_proposal_pda(multisig_pubkey, tx_index);
+    println!(
+        "🎯 Transaction PDA: {}",
+        transaction_pda.to_string().bright_white()
+    );
+    println!(
+        "🎯 Proposal PDA: {}",
+        proposal_pda.to_string().bright_white()
     );
     println!();
-    println!(
-        "🎯 Multisig address: {}",
-        multisig_pubkey.to_string().bright_white()
-    );
+    if let Err(e) = fetch_and_display_transaction(rpc_client, &transaction_pda, tx_index) {
+        println!(
+            "❌ Failed to fetch transaction {}: {}",
+            tx_index,
+            e.to_string().bright_red()
+        );
+    }
+    if let Err(e) = fetch_and_display_proposal(rpc_client, &proposal_pda, tx_index) {
+        println!(
+            "❌ Failed to fetch proposal {}: {}",
+            tx_index,
+            e.to_string().bright_red()
+        );
+    }
     println!();
+}
 
-    // Display the multisig details
-    display_multisig_details(&multisig, &multisig_pubkey)?;
-
-    // Fetch and display transaction and proposal details for all live indices.
-    let rpc_client = create_rpc_client(&rpc_url);
-    fetch_and_display_transactions_and_proposals(&rpc_client, &multisig_pubkey, &multisig)?;
-
-    Ok(())
+/// Offer the instruction-level view interactively. Skipped when not attached
+/// to a terminal or in non-interactive modes; `--index` reaches it directly.
+fn offer_detail_drilldown(
+    rpc_client: &RpcClient,
+    multisig_pubkey: &Pubkey,
+    multisig: &Multisig,
+) -> Result<()> {
+    if multisig.transaction_index == 0
+        || !std::io::stdin().is_terminal()
+        || is_e2e_test_mode()
+        || is_assume_yes()
+    {
+        return Ok(());
+    }
+    loop {
+        let mut options: Vec<String> = (1..=multisig.transaction_index)
+            .map(|i| format!("#{i}"))
+            .collect();
+        options.push("Done".to_string());
+        let selection = match Select::new("View full details for a proposal (debugging)?", options)
+            .raw_prompt()
+        {
+            Ok(selection) => selection,
+            Err(inquire::InquireError::OperationCanceled) => return Ok(()),
+            Err(e) => return Err(e.into()),
+        };
+        if selection.index as u64 >= multisig.transaction_index {
+            return Ok(());
+        }
+        display_full_details(rpc_client, multisig_pubkey, selection.index as u64 + 1);
+    }
 }
 
 /// Print the multisig members table (member index, pubkey, decoded permissions,
@@ -111,9 +381,13 @@ pub(crate) fn print_members_table(multisig: &Multisig) {
         .enumerate()
         .map(|(i, member)| {
             let perms = decode_permissions(member.permissions.mask);
+            let pubkey = match known_signer_name(&member.key) {
+                Some(name) => format!("{} ({name})", member.key),
+                None => member.key.to_string(),
+            };
             MemberInfo {
                 index: i + 1,
-                pubkey: member.key.to_string(),
+                pubkey,
                 permissions: if perms.is_empty() {
                     "None".to_string()
                 } else {
@@ -128,201 +402,6 @@ pub(crate) fn print_members_table(multisig: &Multisig) {
     members_table.with(Style::rounded());
     println!("{}", members_table);
     println!();
-}
-
-fn display_multisig_details(multisig: &Multisig, address: &Pubkey) -> Result<()> {
-    println!("{}", "📋 MULTISIG DETAILS".bright_green().bold());
-    println!("{}", "═".repeat(80).bright_green());
-    println!();
-
-    // Basic info table
-    #[derive(Tabled)]
-    struct MultisigInfo {
-        #[tabled(rename = "Property")]
-        property: String,
-        #[tabled(rename = "Value")]
-        value: String,
-    }
-
-    let info_data = vec![
-        MultisigInfo {
-            property: "Multisig Address".to_string(),
-            value: address.to_string(),
-        },
-        MultisigInfo {
-            property: "Create Key".to_string(),
-            value: multisig.create_key.to_string(),
-        },
-        MultisigInfo {
-            property: "Config Authority".to_string(),
-            value: multisig.config_authority.to_string(),
-        },
-        MultisigInfo {
-            property: "Threshold".to_string(),
-            value: {
-                let voting_members_count = multisig
-                    .members
-                    .iter()
-                    .filter(|member| member.permissions.mask & 2 != 0) // Check Vote permission (bit 1)
-                    .count();
-                format!(
-                    "{} of {} voting members",
-                    multisig.threshold, voting_members_count
-                )
-            },
-        },
-        MultisigInfo {
-            property: "Time Lock (seconds)".to_string(),
-            value: multisig.time_lock.to_string(),
-        },
-        MultisigInfo {
-            property: "Transaction Index".to_string(),
-            value: multisig.transaction_index.to_string(),
-        },
-        MultisigInfo {
-            property: "Stale Transaction Index".to_string(),
-            value: multisig.stale_transaction_index.to_string(),
-        },
-        MultisigInfo {
-            property: "Rent Collector".to_string(),
-            value: multisig
-                .rent_collector
-                .map(|r| r.to_string())
-                .unwrap_or_else(|| "None".to_string()),
-        },
-        MultisigInfo {
-            property: "PDA Bump".to_string(),
-            value: multisig.bump.to_string(),
-        },
-    ];
-
-    let mut info_table = Table::new(info_data);
-    info_table.with(Style::rounded());
-    println!("{}", info_table);
-    println!();
-
-    // Members table (shared with the `verify` command)
-    print_members_table(multisig);
-
-    // Calculate and display vault addresses for common indices
-    println!("{}", "🏦 VAULT ADDRESSES".bright_cyan().bold());
-    println!();
-
-    #[derive(Tabled)]
-    struct VaultInfo {
-        #[tabled(rename = "Index")]
-        index: u8,
-        #[tabled(rename = "Vault Address")]
-        address: String,
-        #[tabled(rename = "Description")]
-        description: String,
-    }
-
-    let vault_data = vec![
-        VaultInfo {
-            index: 0,
-            address: get_vault_pda(address, 0).0.to_string(),
-            description: "Default vault (commonly used for feature gates)".to_string(),
-        },
-        VaultInfo {
-            index: 1,
-            address: get_vault_pda(address, 1).0.to_string(),
-            description: "Vault #1".to_string(),
-        },
-        VaultInfo {
-            index: 2,
-            address: get_vault_pda(address, 2).0.to_string(),
-            description: "Vault #2".to_string(),
-        },
-    ];
-
-    let mut vault_table = Table::new(vault_data);
-    vault_table.with(Style::rounded());
-    println!("{}", vault_table);
-    println!();
-
-    println!(
-        "{}",
-        "✅ Multisig details retrieved successfully!".bright_green()
-    );
-
-    Ok(())
-}
-
-fn fetch_and_display_transactions_and_proposals(
-    rpc_client: &RpcClient,
-    multisig_pubkey: &Pubkey,
-    multisig: &Multisig,
-) -> Result<()> {
-    println!("{}", "🔄 TRANSACTIONS & PROPOSALS".bright_yellow().bold());
-    println!("{}", "═".repeat(80).bright_yellow());
-    println!();
-
-    // Check if there are any transactions to display
-    if multisig.transaction_index == 0 {
-        println!("🔍 No transactions found (transaction_index = 0)");
-        println!();
-        return Ok(());
-    }
-
-    println!(
-        "🔍 Fetching transaction and proposal data for {} transaction(s)...",
-        multisig.transaction_index
-    );
-    println!();
-
-    // Fetch data for all transactions
-    for tx_index in 1..=multisig.transaction_index {
-        println!(
-            "{}",
-            format!("📋 TRANSACTION INDEX {}", tx_index)
-                .bright_cyan()
-                .bold()
-        );
-        println!("{}", "─".repeat(50).bright_cyan());
-
-        // Generate PDAs for transaction and proposal
-        let (transaction_pda, _) = get_transaction_pda(multisig_pubkey, tx_index);
-        let (proposal_pda, _) = get_proposal_pda(multisig_pubkey, tx_index);
-
-        println!(
-            "🎯 Transaction PDA: {}",
-            transaction_pda.to_string().bright_white()
-        );
-        println!(
-            "🎯 Proposal PDA: {}",
-            proposal_pda.to_string().bright_white()
-        );
-        println!();
-
-        // Fetch transaction account
-        match fetch_and_display_transaction(rpc_client, &transaction_pda, tx_index) {
-            Ok(_) => {}
-            Err(e) => {
-                println!(
-                    "❌ Failed to fetch transaction {}: {}",
-                    tx_index,
-                    e.to_string().bright_red()
-                );
-            }
-        }
-
-        // Fetch proposal account
-        match fetch_and_display_proposal(rpc_client, &proposal_pda, tx_index) {
-            Ok(_) => {}
-            Err(e) => {
-                println!(
-                    "❌ Failed to fetch proposal {}: {}",
-                    tx_index,
-                    e.to_string().bright_red()
-                );
-            }
-        }
-
-        println!();
-    }
-
-    Ok(())
 }
 
 /// Enum to hold either transaction type

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -5,9 +5,9 @@ use crate::provision::{create_rpc_client, fetch_squads_multisig};
 use crate::squads::{Multisig, PERMISSION_VOTE};
 use crate::utils::{get_network_display, is_mainnet, validate_pubkey_with_retry, Config};
 use crate::verification::{
-    config_fingerprint, is_autonomous, is_mainnet_cluster, multisig_safety_warnings,
-    program_warnings, verify_feature_gate, verify_squads_program, FeatureVerification,
-    ProgramAuthenticity,
+    config_fingerprint, is_autonomous, is_mainnet_cluster, is_rekeyed, member_set_warnings,
+    multisig_safety_warnings, program_warnings, verify_feature_gate, verify_squads_program,
+    FeatureVerification, ProgramAuthenticity,
 };
 use eyre::Result;
 use solana_pubkey::Pubkey;
@@ -89,7 +89,7 @@ fn verify_on_network(rpc: &RpcClient, multisig: &Pubkey, is_mainnet: bool) -> Op
 /// Flag governance-config drift across networks. The tool deploys identical
 /// config everywhere, so any difference between the clusters where the multisig
 /// exists points to a tampered or stale deployment.
-fn report_cross_network_consistency(seen: &[(&str, Multisig)]) {
+pub(crate) fn report_cross_network_consistency(seen: &[(&str, Multisig)]) {
     if seen.len() < 2 {
         return;
     }
@@ -185,9 +185,17 @@ fn display_owners(ms: &Multisig) {
         &is_autonomous(ms).to_string(),
     );
     Output::field("Time lock", &format!("{}s", ms.time_lock));
+    if is_rekeyed(ms) {
+        Output::warning(
+            "This multisig has been rekeyed: its voting keys cannot meet the threshold, so no proposal can ever pass and the configuration is permanently frozen.",
+        );
+    }
     print_members_table(ms);
 
     for warning in multisig_safety_warnings(ms) {
+        Output::warning(&warning);
+    }
+    for warning in member_set_warnings(ms) {
         Output::warning(&warning);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,16 @@ The contributor key receives Initiate-only permissions, while additional members
     Show {
         #[arg(help = "The multisig address to inspect")]
         address: Option<String>,
+        #[arg(
+            long,
+            help = "Network to inspect: a configured network name (devnet/testnet/mainnet) or an RPC URL. Prompts when omitted and several networks are configured"
+        )]
+        network: Option<String>,
+        #[arg(
+            long,
+            help = "Print full transaction/proposal details (the debugging view) for this proposal index"
+        )]
+        index: Option<u64>,
     },
     #[command(
         about = "Verify a feature gate multisig: program authenticity, feature state, owners"
@@ -251,7 +261,11 @@ fn handle_command(command: Commands) -> Result<()> {
 
             create_command(&mut config, threshold_option, keypair)
         }
-        Commands::Show { address } => show_command(&config, address),
+        Commands::Show {
+            address,
+            network,
+            index,
+        } => show_command(&config, address, network, index),
         Commands::Verify { address } => verify_command(&config, address),
         Commands::Propose { args } => run_proposal(&config, ProposalCommand::Propose, args, None),
         Commands::Approve { args, index } => {

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -264,6 +264,99 @@ pub fn is_autonomous(ms: &Multisig) -> bool {
     ms.config_authority == Pubkey::default()
 }
 
+/// True when the multisig can never pass another proposal: its usable voting
+/// keys cannot meet the threshold. The rekey flow deliberately produces this
+/// state (a single `Pubkey::default()` member, which can never sign),
+/// permanently freezing the feature gate's configuration.
+pub fn is_rekeyed(ms: &Multisig) -> bool {
+    let usable_voters = ms
+        .members
+        .iter()
+        .filter(|m| {
+            m.key != Pubkey::default() && m.permissions.mask & crate::squads::PERMISSION_VOTE != 0
+        })
+        .count();
+    usable_voters < usize::from(ms.threshold)
+}
+
+/// The expected feature gate governance signers: each party's stable voting
+/// key (an EOA or, more likely, its parent multisig's vault-0 PDA), which
+/// recurs as a member across every feature gate multisig.
+///
+/// Vendored like [`SQUADS_V4_PROGRAM_HASH`]: expectations live in reviewed
+/// code, not editable config. Fill in once the parties' keys are known, e.g.:
+///
+/// ```text
+/// ("Org A", Pubkey::from_str_const("...")),
+/// ("Org B", Pubkey::from_str_const("...")),
+/// ("Org C", Pubkey::from_str_const("...")),
+/// ```
+///
+/// While empty, the member-set check is skipped.
+pub const KNOWN_SIGNERS: &[(&str, Pubkey)] = &[];
+
+/// The vendored name for a known governance signer key, if any.
+pub fn known_signer_name(key: &Pubkey) -> Option<&'static str> {
+    KNOWN_SIGNERS
+        .iter()
+        .find(|(_, known)| known == key)
+        .map(|(name, _)| *name)
+}
+
+/// Warnings when the multisig's voting members differ from the vendored
+/// expected signer set. Empty when [`KNOWN_SIGNERS`] is empty. Initiate-only
+/// members (the ephemeral contributor key) are ignored: only keys that can
+/// vote matter for governance.
+pub fn member_set_warnings(ms: &Multisig) -> Vec<String> {
+    member_set_warnings_against(ms, KNOWN_SIGNERS)
+}
+
+fn member_set_warnings_against(ms: &Multisig, known: &[(&str, Pubkey)]) -> Vec<String> {
+    use crate::squads::{PERMISSION_EXECUTE, PERMISSION_VOTE};
+
+    if known.is_empty() {
+        return Vec::new();
+    }
+
+    let mut warnings = Vec::new();
+    for (name, key) in known {
+        let is_voting_member = ms
+            .members
+            .iter()
+            .any(|m| m.key == *key && m.permissions.mask & PERMISSION_VOTE != 0);
+        if !is_voting_member {
+            warnings.push(format!(
+                "Expected signer {name} ({key}) is not a voting member of this multisig."
+            ));
+        }
+    }
+
+    // Any extra member that can vote or execute is a party with power over
+    // governance; only pure Initiate-only members (the expected contributor
+    // pattern) are exempt.
+    for member in &ms.members {
+        if member.permissions.mask & (PERMISSION_VOTE | PERMISSION_EXECUTE) == 0 {
+            continue;
+        }
+        if known.iter().any(|(_, k)| k == &member.key) {
+            continue;
+        }
+        let abilities = match (
+            member.permissions.mask & PERMISSION_VOTE != 0,
+            member.permissions.mask & PERMISSION_EXECUTE != 0,
+        ) {
+            (true, true) => "vote and execute",
+            (true, false) => "vote",
+            (false, _) => "execute proposals",
+        };
+        warnings.push(format!(
+            "Member {} can {abilities} but is not one of the expected governance signers.",
+            member.key
+        ));
+    }
+    warnings
+}
+
 /// A canonical fingerprint of a multisig's governance-relevant config, for
 /// detecting drift across networks. Covers threshold, config authority, time
 /// lock, and the member set (key + permissions), order-independent.
@@ -475,6 +568,82 @@ mod tests {
         assert!(multisig_safety_warnings(&delayed)
             .iter()
             .any(|w| w.contains("time lock")));
+    }
+
+    #[test]
+    fn detects_rekeyed_multisigs() {
+        use crate::squads::{Member, Permissions};
+
+        // Healthy: one real voter, threshold 1.
+        let healthy = multisig_with(Pubkey::default(), 0, 1);
+        assert!(!is_rekeyed(&healthy));
+
+        // Canonical rekey shape: only the unsignable default-pubkey member.
+        let mut rekeyed = multisig_with(Pubkey::default(), 0, 1);
+        rekeyed.members = vec![Member {
+            key: Pubkey::default(),
+            permissions: Permissions::all(),
+        }];
+        assert!(is_rekeyed(&rekeyed));
+
+        // Quorum impossible more generally: threshold above the usable voters.
+        let stuck = multisig_with(Pubkey::default(), 0, 3);
+        assert!(is_rekeyed(&stuck));
+    }
+
+    #[test]
+    fn member_set_warnings_compare_voting_members_only() {
+        use crate::squads::{Member, Permissions};
+        let org_a = Pubkey::new_unique();
+        let org_b = Pubkey::new_unique();
+        let stranger = Pubkey::new_unique();
+        let contributor = Pubkey::new_unique();
+        let known = [("Org A", org_a), ("Org B", org_b)];
+
+        let mut ms = multisig_with(Pubkey::default(), 0, 2);
+        ms.members = vec![
+            Member {
+                key: org_a,
+                permissions: Permissions::all(),
+            },
+            Member {
+                key: org_b,
+                permissions: Permissions::all(),
+            },
+            // Initiate-only contributor must not trip the check.
+            Member {
+                key: contributor,
+                permissions: Permissions { mask: 1 },
+            },
+        ];
+        assert!(member_set_warnings_against(&ms, &known).is_empty());
+
+        // A missing expected signer and an unexpected voter both warn.
+        ms.members[1].key = stranger;
+        let warnings = member_set_warnings_against(&ms, &known);
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Org B") && w.contains("not a voting member")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains(&stranger.to_string()) && w.contains("not one of the expected")));
+
+        // An unexpected executor (no vote) warns too; extra powers over
+        // governance are not limited to voting.
+        ms.members[1] = Member {
+            key: org_b,
+            permissions: Permissions::all(),
+        };
+        ms.members.push(Member {
+            key: stranger,
+            permissions: Permissions { mask: 4 },
+        });
+        let warnings = member_set_warnings_against(&ms, &known);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("execute proposals"));
+
+        // Empty registry (the current vendored state): check is skipped.
+        assert!(member_set_warnings_against(&ms, &[]).is_empty());
     }
 
     #[test]

--- a/tests/rpc_e2e.rs
+++ b/tests/rpc_e2e.rs
@@ -43,7 +43,7 @@ use feature_gate_multisig_tool::squads::{
 };
 use feature_gate_multisig_tool::utils::Config;
 use feature_gate_multisig_tool::verification::{
-    is_autonomous, is_mainnet_cluster, verify_feature_gate, verify_squads_program,
+    is_autonomous, is_mainnet_cluster, is_rekeyed, verify_feature_gate, verify_squads_program,
     FeatureGateStatus,
 };
 
@@ -917,6 +917,10 @@ fn rpc_e2e_6_rekey_feature_gate_multisig() {
         multisig.members[0].key,
         Pubkey::default(),
         "remaining member should be the default pubkey (dummy owner)"
+    );
+    assert!(
+        is_rekeyed(&multisig),
+        "rekey detection should flag the post-rekey state"
     );
 
     println!("✅ Feature gate rekey E2E test completed successfully!");


### PR DESCRIPTION
`show` used to dump every transaction at instruction level while never
answering the main question: what state is the feature gate in? This turns it
into a status page and folds in the cheap verification checks.

### show
- New summary header: feature gate address, its state on every configured
  network, threshold, autonomy, and time lock
- Auto-runs verification inline: program authenticity (bytecode check) on the
  inspected network, autonomy/time-lock warnings, and the cross-network config
  drift check. `verify` stays the all-networks authenticity audit.
- Proposals render one row each: kind (classified from the on-chain
  transaction shape), status, and vote counts
- Detects parent (voting) multisigs from their transactions and reframes the
  header - vault 0 is labeled the voting identity, not a feature gate, and the
  feature-state line is dropped where it has no meaning
- Instruction-level view kept for debugging: `show <addr> --index N`, or an
  optional drill-down prompt interactively (TTY only, so piped output is clean)
- `--network` flag, matching the proposal subcommands
- Dropped from the default view: PDA bumps, create key, stale index, and the
  vault 1/2 addresses this tool never uses

### verification
- Rekey detection: `show`/`verify` warn when a multisig's voting keys can no
  longer meet the threshold (permanently frozen). Reported per network, since
  rekey is per-cluster - it can be frozen on one network and active on others.
- Expected-signer scaffolding: a vendored `KNOWN_SIGNERS` registry (empty for
  now). Once filled, `verify`/`show` warn when an expected signer is missing or
  any extra member can vote or execute, and the members table annotates matched
  keys with their org name.
